### PR TITLE
Fix OS and Browser conditions for multi-value configuration parsing

### DIFF
--- a/core/src/main/java/io/github/mabartos/context/browser/BrowserConditionFactory.java
+++ b/core/src/main/java/io/github/mabartos/context/browser/BrowserConditionFactory.java
@@ -55,11 +55,19 @@ public class BrowserConditionFactory extends UserContextConditionFactory<DeviceC
                 .add()
                 .operation()
                     .operationKey(DefaultOperation.ANY_OF)
-                    .condition((dev, val) -> List.of(val.split(",")).contains(dev.getData().map(DeviceRepresentation::getBrowser).orElse("<unknown>")))
+                    .condition((dev, val) -> {
+                        List<String> browsers = List.of(val.split("##"));
+                        String detectedBrowser = dev.getData().map(DeviceRepresentation::getBrowser).orElse("<unknown>");
+                        return browsers.stream().anyMatch(detectedBrowser::startsWith);
+                    })
                 .add()
                 .operation()
                     .operationKey(DefaultOperation.NONE_OF)
-                    .condition((dev, val) -> !List.of(val.split(",")).contains(dev.getData().map(DeviceRepresentation::getBrowser).orElse("<unknown>")))
+                    .condition((dev, val) -> {
+                        List<String> browsers = List.of(val.split("##"));
+                        String detectedBrowser = dev.getData().map(DeviceRepresentation::getBrowser).orElse("<unknown>");
+                        return browsers.stream().noneMatch(detectedBrowser::startsWith);
+                    })
                 .add()
                 .build();
     }

--- a/core/src/main/java/io/github/mabartos/context/os/OperatingSystemConditionFactory.java
+++ b/core/src/main/java/io/github/mabartos/context/os/OperatingSystemConditionFactory.java
@@ -98,11 +98,11 @@ public class OperatingSystemConditionFactory extends UserContextConditionFactory
                 .add()
                 .operation()
                     .operationKey(DefaultOperation.ANY_OF)
-                    .condition((dev, val) -> List.of(val.split(",")).contains(dev.getData().map(DeviceRepresentation::getOs).orElse("<unknown>")))
+                    .condition((dev, val) -> List.of(val.split("##")).contains(dev.getData().map(DeviceRepresentation::getOs).orElse("<unknown>")))
                 .add()
                 .operation()
                     .operationKey(DefaultOperation.NONE_OF)
-                    .condition((dev, val) -> !List.of(val.split(",")).contains(dev.getData().map(DeviceRepresentation::getOs).orElse("<unknown>")))
+                    .condition((dev, val) -> !List.of(val.split("##")).contains(dev.getData().map(DeviceRepresentation::getOs).orElse("<unknown>")))
                 .add()
                 .build();
     }


### PR DESCRIPTION
This PR fixes an issue where OS-based and Browser-based restrictions were not working correctly when multiple configuration values were selected (see #27).

### Problem

- The configuration values for OS and Browser conditions are defined as multi-valued lists in Keycloak.
- However, the condition logic was incorrectly splitting values using "," instead of the correct Keycloak multi-value separator "##".
- As a result, operations like “is any of” and “is none of” never matched correctly.
- Additionally, the browser matching logic did not properly account for how browser names are represented (e.g. versioned user agent values).

### Solution

- Updated OS and Browser condition parsing to split multi-valued configuration inputs using the correct "##" delimiter.
- Adjusted the Browser condition logic to correctly evaluate browser values against the detected device/browser context.
- Ensured that multi-value operations (ANY_OF, NONE_OF) now behave consistently with Keycloak’s configuration model.


Fixes #27 