### PR TITLE
🛠️ [Fix] country/city location conditions + add tests

### DIFF
--- a/core/src/main/java/io/github/mabartos/context/ip/client/TestIpAddressContext.java
+++ b/core/src/main/java/io/github/mabartos/context/ip/client/TestIpAddressContext.java
@@ -4,33 +4,108 @@ import io.github.mabartos.context.ip.IPAddress;
 import io.github.mabartos.context.DeviceContext;
 import io.github.mabartos.context.ip.IpAddressUtils;
 import jakarta.annotation.Nonnull;
+import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
 
 public class TestIpAddressContext extends IpAddressContext {
+    private static final Logger log = Logger.getLogger(TestIpAddressContext.class);
+
     public static final String TESTING_IP = "77.75.72.3"; // seznam.cz
     public static final String USE_TESTING_IP_PROP = "ip.address.use.testing";
+    public static final String TESTING_IP_VALUE_PROP = "ip.address.testing.value";
+    public static final String TESTING_IP_RANDOM_PROP = "ip.address.testing.random.enabled";
+
+    private static final List<String> TESTING_IPS = List.of(
+            "176.150.253.172", // France
+            "191.101.157.70",  // Germany
+            "79.142.79.54",    // Switzerland
+            "212.112.19.28",   // Sweden
+            "212.102.49.216"   // Spain
+    );
 
     public TestIpAddressContext(KeycloakSession session) {
         super(session);
     }
 
     public static boolean isTestIpAddressUsed() {
-        return Boolean.parseBoolean(System.getProperty(USE_TESTING_IP_PROP, "false"));
-    }
-
-    @Override
-    public boolean alwaysFetch() {
-        return true;
+        return isLegacyTestingIpEnabled() || isRandomTestingIpEnabled() || !getConfiguredTestingIps().isEmpty();
     }
 
     @Override
     public Optional<IPAddress> initData(@Nonnull RealmModel realm) {
         if (isTestIpAddressUsed()) {
-            return IpAddressUtils.getIpAddress(TESTING_IP);
+            return IpAddressUtils.getIpAddress(resolveTestingIp());
         }
         return Optional.empty();
+    }
+
+    private static String resolveTestingIp() {
+        List<String> configuredIps = getConfiguredTestingIps();
+
+        if (!configuredIps.isEmpty()) {
+            boolean useRandomIp = isRandomTestingIpEnabled();
+            if (useRandomIp && configuredIps.size() > 1) {
+                String ip = configuredIps.get(ThreadLocalRandom.current().nextInt(configuredIps.size()));
+                log.tracef("Using random configured testing IP: %s", ip);
+                return ip;
+            }
+
+            String ip = configuredIps.getFirst();
+            log.tracef("Using configured testing IP: %s", ip);
+            return ip;
+        }
+
+        boolean useRandomIp = isRandomTestingIpEnabled();
+        if (useRandomIp && !TESTING_IPS.isEmpty()) {
+            String ip = TESTING_IPS.get(ThreadLocalRandom.current().nextInt(TESTING_IPS.size()));
+            log.tracef("Using random testing IP: %s", ip);
+            return ip;
+        }
+
+        return TESTING_IP;
+    }
+
+    private static boolean isLegacyTestingIpEnabled() {
+        return getConfigValue(USE_TESTING_IP_PROP)
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    private static boolean isRandomTestingIpEnabled() {
+        return getConfigValue(TESTING_IP_RANDOM_PROP)
+                .map(Boolean::parseBoolean)
+                .orElse(false);
+    }
+
+    private static List<String> getConfiguredTestingIps() {
+        return getConfigValue(TESTING_IP_VALUE_PROP)
+                .stream()
+                .flatMap(value -> Stream.of(value.split(",")))
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .filter(TestIpAddressContext::isValidIp)
+                .toList();
+    }
+
+    private static Optional<String> getConfigValue(String key) {
+        return Configuration.getOptionalValue(key)
+                .or(() -> Optional.ofNullable(System.getProperty(key)))
+                .map(String::trim)
+                .filter(value -> !value.isBlank());
+    }
+
+    private static boolean isValidIp(String ip) {
+        boolean valid = IPAddress.parse(ip) != null;
+        if (!valid) {
+            log.warnf("Invalid configured testing IP: %s", ip);
+        }
+        return valid;
     }
 }

--- a/core/src/main/java/io/github/mabartos/context/ip/client/TestIpAddressContext.java
+++ b/core/src/main/java/io/github/mabartos/context/ip/client/TestIpAddressContext.java
@@ -1,7 +1,6 @@
 package io.github.mabartos.context.ip.client;
 
 import io.github.mabartos.context.ip.IPAddress;
-import io.github.mabartos.context.DeviceContext;
 import io.github.mabartos.context.ip.IpAddressUtils;
 import jakarta.annotation.Nonnull;
 import org.jboss.logging.Logger;
@@ -35,18 +34,15 @@ public class TestIpAddressContext extends IpAddressContext {
     }
 
     public static boolean isTestIpAddressUsed() {
-        return isLegacyTestingIpEnabled() || isRandomTestingIpEnabled() || !getConfiguredTestingIps().isEmpty();
+        return resolveTestingIp().isPresent();
     }
 
     @Override
     public Optional<IPAddress> initData(@Nonnull RealmModel realm) {
-        if (isTestIpAddressUsed()) {
-            return IpAddressUtils.getIpAddress(resolveTestingIp());
-        }
-        return Optional.empty();
+        return resolveTestingIp().flatMap(IpAddressUtils::getIpAddress);
     }
 
-    private static String resolveTestingIp() {
+    private static Optional<String> resolveTestingIp() {
         List<String> configuredIps = getConfiguredTestingIps();
 
         if (!configuredIps.isEmpty()) {
@@ -54,22 +50,26 @@ public class TestIpAddressContext extends IpAddressContext {
             if (useRandomIp && configuredIps.size() > 1) {
                 String ip = configuredIps.get(ThreadLocalRandom.current().nextInt(configuredIps.size()));
                 log.tracef("Using random configured testing IP: %s", ip);
-                return ip;
+                return Optional.of(ip);
             }
 
             String ip = configuredIps.getFirst();
             log.tracef("Using configured testing IP: %s", ip);
-            return ip;
+            return Optional.of(ip);
         }
 
         boolean useRandomIp = isRandomTestingIpEnabled();
         if (useRandomIp && !TESTING_IPS.isEmpty()) {
             String ip = TESTING_IPS.get(ThreadLocalRandom.current().nextInt(TESTING_IPS.size()));
             log.tracef("Using random testing IP: %s", ip);
-            return ip;
+            return Optional.of(ip);
         }
 
-        return TESTING_IP;
+        if (isLegacyTestingIpEnabled()) {
+            return Optional.of(TESTING_IP);
+        }
+
+        return Optional.empty();
     }
 
     private static boolean isLegacyTestingIpEnabled() {

--- a/core/src/main/java/io/github/mabartos/context/location/AuthnSessionLocationContext.java
+++ b/core/src/main/java/io/github/mabartos/context/location/AuthnSessionLocationContext.java
@@ -53,8 +53,7 @@ public class AuthnSessionLocationContext extends LocationContext {
             return Optional.empty();
         }
 
-        // Get current IP address
-        var currentIp = ipAddressContext.getData(realm).orElse(null);
+        IPAddress currentIp = ipAddressContext.getData(realm).orElse(null);
         if (currentIp == null) {
             log.trace("No IP address available");
             return Optional.empty();
@@ -73,7 +72,12 @@ public class AuthnSessionLocationContext extends LocationContext {
         return Optional.empty();
     }
 
-    static void updateCache(AuthenticationSessionModel authSession, IPAddress ip, LocationData location) {
+    public void updateCache(IPAddress ip, LocationData location) {
+        AuthenticationSessionModel authSession = session.getContext().getAuthenticationSession();
+        if (authSession == null || ip == null || location == null) {
+            return;
+        }
+
         authSession.setAuthNote(LAST_IP_KEY, ip.toString());
         String locationString = LocationDataUtils.formatToAttribute(location);
         authSession.setAuthNote(LAST_LOCATION_KEY, locationString);

--- a/core/src/main/java/io/github/mabartos/context/location/GlobalCacheLocationContext.java
+++ b/core/src/main/java/io/github/mabartos/context/location/GlobalCacheLocationContext.java
@@ -1,0 +1,44 @@
+package io.github.mabartos.context.location;
+
+import io.github.mabartos.context.UserContexts;
+import io.github.mabartos.context.ip.IPAddress;
+import io.github.mabartos.context.ip.client.IpAddressContext;
+import jakarta.annotation.Nonnull;
+import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+import java.util.Optional;
+
+/**
+ * LocationContext backed by the JVM-wide location cache.
+ */
+public class GlobalCacheLocationContext extends LocationContext {
+    private static final Logger log = Logger.getLogger(GlobalCacheLocationContext.class);
+
+    private final IpAddressContext ipAddressContext;
+
+    public GlobalCacheLocationContext(KeycloakSession session) {
+        super(session);
+        this.ipAddressContext = UserContexts.getContext(session, IpAddressContext.class);
+    }
+
+    @Override
+    public Optional<LocationData> initData(@Nonnull RealmModel realm) {
+        IPAddress currentIp = ipAddressContext.getData(realm).orElse(null);
+        if (currentIp == null) {
+            log.trace("No IP address available");
+            return Optional.empty();
+        }
+
+        return GlobalLocationCache.get(currentIp);
+    }
+
+    public void updateCache(IPAddress ip, LocationData location) {
+        if (ip == null || location == null) {
+            return;
+        }
+
+        GlobalLocationCache.put(ip, location);
+    }
+}

--- a/core/src/main/java/io/github/mabartos/context/location/GlobalCacheLocationContextFactory.java
+++ b/core/src/main/java/io/github/mabartos/context/location/GlobalCacheLocationContextFactory.java
@@ -1,0 +1,28 @@
+package io.github.mabartos.context.location;
+
+import io.github.mabartos.spi.context.UserContextFactory;
+import org.keycloak.models.KeycloakSession;
+
+public class GlobalCacheLocationContextFactory implements UserContextFactory<LocationContext> {
+    public static final String PROVIDER_ID = "global-cache-location-context";
+
+    @Override
+    public GlobalCacheLocationContext create(KeycloakSession session) {
+        return new GlobalCacheLocationContext(session);
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+
+    @Override
+    public Class<LocationContext> getUserContextClass() {
+        return LocationContext.class;
+    }
+
+    @Override
+    public int getPriority() {
+        return 50;
+    }
+}

--- a/core/src/main/java/io/github/mabartos/context/location/GlobalLocationCache.java
+++ b/core/src/main/java/io/github/mabartos/context/location/GlobalLocationCache.java
@@ -1,46 +1,81 @@
 package io.github.mabartos.context.location;
 
-import inet.ipaddr.IPAddress;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import io.github.mabartos.context.ip.IPAddress;
 import org.jboss.logging.Logger;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 
 import java.time.Duration;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 final class GlobalLocationCache {
     private static final Logger log = Logger.getLogger(GlobalLocationCache.class);
 
-    private static final long TTL_MILLIS = Duration.ofHours(24).toMillis();
-    private static final ConcurrentHashMap<String, CacheEntry> CACHE = new ConcurrentHashMap<>();
+    private static final String TTL_PROPERTY = "location.global-cache.ttl";
+    private static final String MAXIMUM_SIZE_PROPERTY = "location.global-cache.maximum-size";
+
+    private static final Duration DEFAULT_TTL = Duration.ofHours(24);
+    private static final long DEFAULT_MAXIMUM_SIZE = 10_000L;
+
+    private static final Cache<String, LocationData> CACHE = Caffeine.newBuilder()
+            .expireAfterWrite(resolveTtl())
+            .maximumSize(resolveMaximumSize())
+            .removalListener(GlobalLocationCache::onRemoval)
+            .build();
 
     private GlobalLocationCache() {
     }
 
     static Optional<LocationData> get(IPAddress ip) {
-        String ipString = ip.toString();
-        CacheEntry entry = CACHE.get(ipString);
-        if (entry == null) {
-            return Optional.empty();
-        }
-
-        if (entry.isExpired()) {
-            CACHE.remove(ipString, entry);
-            log.tracef("Expired global location cache entry removed for IP=%s", ipString);
-            return Optional.empty();
-        }
-
-        return Optional.of(entry.location());
+        return Optional.ofNullable(CACHE.getIfPresent(ip.toString()));
     }
 
     static void put(IPAddress ip, LocationData location) {
         String ipString = ip.toString();
-        CACHE.put(ipString, new CacheEntry(location, System.currentTimeMillis() + TTL_MILLIS));
+        CACHE.put(ipString, location);
         log.tracef("Updated global location cache: IP=%s", ipString);
     }
 
-    private record CacheEntry(LocationData location, long expiresAt) {
-        boolean isExpired() {
-            return System.currentTimeMillis() > expiresAt;
+    private static Duration resolveTtl() {
+        return Configuration.getOptionalValue(TTL_PROPERTY)
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .map(value -> {
+                    try {
+                        return Duration.parse(value);
+                    } catch (RuntimeException e) {
+                        log.warnf("Invalid global location cache TTL '%s', using default %s", value, DEFAULT_TTL);
+                        return DEFAULT_TTL;
+                    }
+                })
+                .orElse(DEFAULT_TTL);
+    }
+
+    private static long resolveMaximumSize() {
+        return Configuration.getOptionalValue(MAXIMUM_SIZE_PROPERTY)
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .map(value -> {
+                    try {
+                        long maximumSize = Long.parseLong(value);
+                        if (maximumSize <= 0) {
+                            throw new IllegalArgumentException("Maximum size must be positive");
+                        }
+                        return maximumSize;
+                    } catch (RuntimeException e) {
+                        log.warnf("Invalid global location cache maximum size '%s', using default %d",
+                                value, DEFAULT_MAXIMUM_SIZE);
+                        return DEFAULT_MAXIMUM_SIZE;
+                    }
+                })
+                .orElse(DEFAULT_MAXIMUM_SIZE);
+    }
+
+    private static void onRemoval(String ip, LocationData location, RemovalCause cause) {
+        if (ip != null && cause.wasEvicted()) {
+            log.tracef("Removed global location cache entry for IP=%s due to %s", ip, cause);
         }
     }
 }

--- a/core/src/main/java/io/github/mabartos/context/location/GlobalLocationCache.java
+++ b/core/src/main/java/io/github/mabartos/context/location/GlobalLocationCache.java
@@ -1,0 +1,46 @@
+package io.github.mabartos.context.location;
+
+import inet.ipaddr.IPAddress;
+import org.jboss.logging.Logger;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+final class GlobalLocationCache {
+    private static final Logger log = Logger.getLogger(GlobalLocationCache.class);
+
+    private static final long TTL_MILLIS = Duration.ofHours(24).toMillis();
+    private static final ConcurrentHashMap<String, CacheEntry> CACHE = new ConcurrentHashMap<>();
+
+    private GlobalLocationCache() {
+    }
+
+    static Optional<LocationData> get(IPAddress ip) {
+        String ipString = ip.toString();
+        CacheEntry entry = CACHE.get(ipString);
+        if (entry == null) {
+            return Optional.empty();
+        }
+
+        if (entry.isExpired()) {
+            CACHE.remove(ipString, entry);
+            log.tracef("Expired global location cache entry removed for IP=%s", ipString);
+            return Optional.empty();
+        }
+
+        return Optional.of(entry.location());
+    }
+
+    static void put(IPAddress ip, LocationData location) {
+        String ipString = ip.toString();
+        CACHE.put(ipString, new CacheEntry(location, System.currentTimeMillis() + TTL_MILLIS));
+        log.tracef("Updated global location cache: IP=%s", ipString);
+    }
+
+    private record CacheEntry(LocationData location, long expiresAt) {
+        boolean isExpired() {
+            return System.currentTimeMillis() > expiresAt;
+        }
+    }
+}

--- a/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContext.java
+++ b/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContext.java
@@ -50,10 +50,8 @@ public class IpApiLocationContext extends LocationContext {
         super(session);
         this.httpClientProvider = session.getProvider(HttpClientProvider.class);
         this.ipAddressContext = UserContexts.getContext(session, IpAddressContext.class);
-        Object authnSessionContext = UserContexts.getContext(session, AuthnSessionLocationContextFactory.PROVIDER_ID);
-        this.authnSessionLocationContext = authnSessionContext instanceof AuthnSessionLocationContext cache ? cache : null;
-        Object globalCacheContext = UserContexts.getContext(session, GlobalCacheLocationContextFactory.PROVIDER_ID);
-        this.globalCacheLocationContext = globalCacheContext instanceof GlobalCacheLocationContext cache ? cache : null;
+        this.authnSessionLocationContext = UserContexts.getContext(session, AuthnSessionLocationContextFactory.PROVIDER_ID);
+        this.globalCacheLocationContext = UserContexts.getContext(session, GlobalCacheLocationContextFactory.PROVIDER_ID);
     }
 
     @Override

--- a/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContext.java
+++ b/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContext.java
@@ -16,6 +16,8 @@
  */
 package io.github.mabartos.context.location;
 
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
 import io.github.mabartos.context.UserContexts;
 import io.github.mabartos.context.ip.client.IpAddressContext;
 import jakarta.annotation.Nonnull;
@@ -26,20 +28,37 @@ import org.jboss.logging.Logger;
 import org.keycloak.connections.httpclient.HttpClientProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.StringUtil;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Obtain location data based on the IP address from 'ipapi.co' server
  */
 public class IpApiLocationContext extends LocationContext {
+
     private static final Logger log = Logger.getLogger(IpApiLocationContext.class);
+
+    private static final String LAST_IP_KEY = "ADAPTIVE_AUTHN_LOCATION_LAST_IP";
+    private static final String LAST_LOCATION_KEY = "ADAPTIVE_AUTHN_LOCATION_LAST_DATA";
+
     private final HttpClientProvider httpClientProvider;
     private final IpAddressContext ipAddressContext;
+
+    /* Override IP with random placeholder for debug */
+    private static final List<String> DEBUG_IPS = List.of(
+            "176.150.253.172", // France
+            "191.101.157.70",  // Germany
+            "79.142.79.54",    // Switzerland
+            "212.112.19.28",   // Sweden
+            "212.102.49.216"   // Spain
+    );
 
     public IpApiLocationContext(KeycloakSession session) {
         super(session);
@@ -52,6 +71,31 @@ public class IpApiLocationContext extends LocationContext {
         return true;
     }
 
+    private IPAddress resolveIpForDebug(IPAddress realIp) {
+        String forcedIp = System.getenv("KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP_ADRESSES");
+        if (forcedIp != null && !forcedIp.isBlank()) {
+            IPAddress parsed = new IPAddressString(forcedIp).getAddress();
+            if (parsed != null) {
+                log.tracef("Forced debug IP from env: %s instead of %s", parsed, realIp);
+                return parsed;
+            }
+            log.warnf("Invalid DEBUG_IP value: %s", forcedIp);
+        }
+
+        String randomEnabled = System.getenv("KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP");
+        if ("true".equalsIgnoreCase(randomEnabled) && !DEBUG_IPS.isEmpty()) {
+            String picked = DEBUG_IPS.get(ThreadLocalRandom.current().nextInt(DEBUG_IPS.size()));
+            IPAddress parsed = new IPAddressString(picked).getAddress();
+            if (parsed != null) {
+                log.tracef("Random debug IP from env: %s instead of %s", parsed, realIp);
+                return parsed;
+            }
+            log.warnf("Invalid IP in DEBUG_IPS: %s", picked);
+        }
+
+        return realIp;
+    }
+
     @Override
     public Optional<LocationData> initData(@Nonnull RealmModel realm) {
         try {
@@ -59,13 +103,33 @@ public class IpApiLocationContext extends LocationContext {
                     .map(f -> f.getData(realm))
                     .flatMap(f -> f.stream().findAny())
                     .orElse(null);
+
             if (ipAddress == null) {
-                log.tracef("Cannot obtain IP address");
+                log.trace("Cannot obtain IP address");
                 return Optional.empty();
             }
 
+            var effectiveIpAddress = resolveIpForDebug(ipAddress);
+            var authSession = session.getContext().getAuthenticationSession();
+
+            // 1. Authentication session cache
+            Optional<LocationData> sessionCached = getFromAuthSessionCache(authSession, effectiveIpAddress);
+            if (sessionCached.isPresent()) {
+                log.tracef("Using authentication session cached location for IP %s", effectiveIpAddress);
+                return sessionCached;
+            }
+
+            // 2. Global JVM cache
+            Optional<LocationData> globalCached = GlobalLocationCache.get(effectiveIpAddress);
+            if (globalCached.isPresent()) {
+                log.tracef("Using global cached location for IP %s", effectiveIpAddress);
+                updateAuthSessionCache(authSession, effectiveIpAddress, globalCached.get());
+                return globalCached;
+            }
+
+            // 3. Remote API call
             var client = httpClientProvider.getHttpClient();
-            var uriString = Optional.of(ipAddress)
+            var uriString = Optional.of(effectiveIpAddress)
                     .map(IpApiLocationContextFactory.SERVICE_URL)
                     .filter(StringUtil::isNotBlank);
 
@@ -82,17 +146,57 @@ public class IpApiLocationContext extends LocationContext {
                     log.error(response.getStatusLine().getReasonPhrase());
                     return Optional.empty();
                 }
-                Optional<LocationData> data = Optional.ofNullable(JsonSerialization.readValue(response.getEntity().getContent(), IpApiLocationData.class));
+
+                Optional<LocationData> data = Optional.ofNullable(
+                        JsonSerialization.readValue(
+                                response.getEntity().getContent(),
+                                IpApiLocationData.class));
+
                 data.ifPresent(location -> {
-                    log.tracef("Location obtained: %s", data);
-                    // update the location cache for authnSession
-                    AuthnSessionLocationContext.updateCache(session.getContext().getAuthenticationSession(), ipAddress, location);
+                    log.tracef("Location obtained: %s", location);
+                    updateAuthSessionCache(authSession, effectiveIpAddress, location);
+                    GlobalLocationCache.put(effectiveIpAddress, location);
                 });
+
                 return data;
             }
         } catch (URISyntaxException | IOException | RuntimeException e) {
-            log.error(e);
+            log.error("Failed to initialize location data", e);
         }
+
         return Optional.empty();
+    }
+
+    private Optional<LocationData> getFromAuthSessionCache(AuthenticationSessionModel authSession, IPAddress currentIp) {
+        if (authSession == null) {
+            log.trace("No authentication session available");
+            return Optional.empty();
+        }
+
+        var cachedIp = authSession.getAuthNote(LAST_IP_KEY);
+        var cachedLocation = authSession.getAuthNote(LAST_LOCATION_KEY);
+        var currentIpString = currentIp.toString();
+
+        if (StringUtil.isNotBlank(cachedIp)
+                && cachedIp.equals(currentIpString)
+                && StringUtil.isNotBlank(cachedLocation)) {
+            log.tracef("IP address unchanged (%s), using authentication session cached location: %s",
+                    cachedIp, cachedLocation);
+            return Optional.ofNullable(LocationDataUtils.parseFromAttribute(cachedLocation));
+        }
+
+        return Optional.empty();
+    }
+
+    private void updateAuthSessionCache(AuthenticationSessionModel authSession, IPAddress ip, LocationData location) {
+        if (authSession == null || ip == null || location == null) {
+            return;
+        }
+
+        String locationString = LocationDataUtils.formatToAttribute(location);
+        authSession.setAuthNote(LAST_IP_KEY, ip.toString());
+        authSession.setAuthNote(LAST_LOCATION_KEY, locationString);
+
+        log.tracef("Updated authentication session location cache: IP=%s, Location=%s", ip, locationString);
     }
 }

--- a/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContext.java
+++ b/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContext.java
@@ -16,9 +16,8 @@
  */
 package io.github.mabartos.context.location;
 
-import inet.ipaddr.IPAddress;
-import inet.ipaddr.IPAddressString;
 import io.github.mabartos.context.UserContexts;
+import io.github.mabartos.context.ip.IPAddress;
 import io.github.mabartos.context.ip.client.IpAddressContext;
 import jakarta.annotation.Nonnull;
 import org.apache.http.client.methods.HttpGet;
@@ -28,15 +27,12 @@ import org.jboss.logging.Logger;
 import org.keycloak.connections.httpclient.HttpClientProvider;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
-import org.keycloak.sessions.AuthenticationSessionModel;
 import org.keycloak.util.JsonSerialization;
 import org.keycloak.utils.StringUtil;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Obtain location data based on the IP address from 'ipapi.co' server
@@ -45,25 +41,19 @@ public class IpApiLocationContext extends LocationContext {
 
     private static final Logger log = Logger.getLogger(IpApiLocationContext.class);
 
-    private static final String LAST_IP_KEY = "ADAPTIVE_AUTHN_LOCATION_LAST_IP";
-    private static final String LAST_LOCATION_KEY = "ADAPTIVE_AUTHN_LOCATION_LAST_DATA";
-
     private final HttpClientProvider httpClientProvider;
     private final IpAddressContext ipAddressContext;
-
-    /* Override IP with random placeholder for debug */
-    private static final List<String> DEBUG_IPS = List.of(
-            "176.150.253.172", // France
-            "191.101.157.70",  // Germany
-            "79.142.79.54",    // Switzerland
-            "212.112.19.28",   // Sweden
-            "212.102.49.216"   // Spain
-    );
+    private final AuthnSessionLocationContext authnSessionLocationContext;
+    private final GlobalCacheLocationContext globalCacheLocationContext;
 
     public IpApiLocationContext(KeycloakSession session) {
         super(session);
         this.httpClientProvider = session.getProvider(HttpClientProvider.class);
         this.ipAddressContext = UserContexts.getContext(session, IpAddressContext.class);
+        Object authnSessionContext = UserContexts.getContext(session, AuthnSessionLocationContextFactory.PROVIDER_ID);
+        this.authnSessionLocationContext = authnSessionContext instanceof AuthnSessionLocationContext cache ? cache : null;
+        Object globalCacheContext = UserContexts.getContext(session, GlobalCacheLocationContextFactory.PROVIDER_ID);
+        this.globalCacheLocationContext = globalCacheContext instanceof GlobalCacheLocationContext cache ? cache : null;
     }
 
     @Override
@@ -71,65 +61,18 @@ public class IpApiLocationContext extends LocationContext {
         return true;
     }
 
-    private IPAddress resolveIpForDebug(IPAddress realIp) {
-        String forcedIp = System.getenv("KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP_ADRESSES");
-        if (forcedIp != null && !forcedIp.isBlank()) {
-            IPAddress parsed = new IPAddressString(forcedIp).getAddress();
-            if (parsed != null) {
-                log.tracef("Forced debug IP from env: %s instead of %s", parsed, realIp);
-                return parsed;
-            }
-            log.warnf("Invalid DEBUG_IP value: %s", forcedIp);
-        }
-
-        String randomEnabled = System.getenv("KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP");
-        if ("true".equalsIgnoreCase(randomEnabled) && !DEBUG_IPS.isEmpty()) {
-            String picked = DEBUG_IPS.get(ThreadLocalRandom.current().nextInt(DEBUG_IPS.size()));
-            IPAddress parsed = new IPAddressString(picked).getAddress();
-            if (parsed != null) {
-                log.tracef("Random debug IP from env: %s instead of %s", parsed, realIp);
-                return parsed;
-            }
-            log.warnf("Invalid IP in DEBUG_IPS: %s", picked);
-        }
-
-        return realIp;
-    }
-
     @Override
     public Optional<LocationData> initData(@Nonnull RealmModel realm) {
         try {
-            var ipAddress = Optional.ofNullable(ipAddressContext)
-                    .map(f -> f.getData(realm))
-                    .flatMap(f -> f.stream().findAny())
-                    .orElse(null);
+            IPAddress ipAddress = ipAddressContext.getData(realm).orElse(null);
 
             if (ipAddress == null) {
                 log.trace("Cannot obtain IP address");
                 return Optional.empty();
             }
 
-            var effectiveIpAddress = resolveIpForDebug(ipAddress);
-            var authSession = session.getContext().getAuthenticationSession();
-
-            // 1. Authentication session cache
-            Optional<LocationData> sessionCached = getFromAuthSessionCache(authSession, effectiveIpAddress);
-            if (sessionCached.isPresent()) {
-                log.tracef("Using authentication session cached location for IP %s", effectiveIpAddress);
-                return sessionCached;
-            }
-
-            // 2. Global JVM cache
-            Optional<LocationData> globalCached = GlobalLocationCache.get(effectiveIpAddress);
-            if (globalCached.isPresent()) {
-                log.tracef("Using global cached location for IP %s", effectiveIpAddress);
-                updateAuthSessionCache(authSession, effectiveIpAddress, globalCached.get());
-                return globalCached;
-            }
-
-            // 3. Remote API call
             var client = httpClientProvider.getHttpClient();
-            var uriString = Optional.of(effectiveIpAddress)
+            var uriString = Optional.of(ipAddress)
                     .map(IpApiLocationContextFactory.SERVICE_URL)
                     .filter(StringUtil::isNotBlank);
 
@@ -154,8 +97,7 @@ public class IpApiLocationContext extends LocationContext {
 
                 data.ifPresent(location -> {
                     log.tracef("Location obtained: %s", location);
-                    updateAuthSessionCache(authSession, effectiveIpAddress, location);
-                    GlobalLocationCache.put(effectiveIpAddress, location);
+                    updateCaches(ipAddress, location);
                 });
 
                 return data;
@@ -167,36 +109,13 @@ public class IpApiLocationContext extends LocationContext {
         return Optional.empty();
     }
 
-    private Optional<LocationData> getFromAuthSessionCache(AuthenticationSessionModel authSession, IPAddress currentIp) {
-        if (authSession == null) {
-            log.trace("No authentication session available");
-            return Optional.empty();
+    private void updateCaches(IPAddress effectiveIpAddress, LocationData location) {
+        if (authnSessionLocationContext != null) {
+            authnSessionLocationContext.updateCache(effectiveIpAddress, location);
         }
 
-        var cachedIp = authSession.getAuthNote(LAST_IP_KEY);
-        var cachedLocation = authSession.getAuthNote(LAST_LOCATION_KEY);
-        var currentIpString = currentIp.toString();
-
-        if (StringUtil.isNotBlank(cachedIp)
-                && cachedIp.equals(currentIpString)
-                && StringUtil.isNotBlank(cachedLocation)) {
-            log.tracef("IP address unchanged (%s), using authentication session cached location: %s",
-                    cachedIp, cachedLocation);
-            return Optional.ofNullable(LocationDataUtils.parseFromAttribute(cachedLocation));
+        if (globalCacheLocationContext != null) {
+            globalCacheLocationContext.updateCache(effectiveIpAddress, location);
         }
-
-        return Optional.empty();
-    }
-
-    private void updateAuthSessionCache(AuthenticationSessionModel authSession, IPAddress ip, LocationData location) {
-        if (authSession == null || ip == null || location == null) {
-            return;
-        }
-
-        String locationString = LocationDataUtils.formatToAttribute(location);
-        authSession.setAuthNote(LAST_IP_KEY, ip.toString());
-        authSession.setAuthNote(LAST_LOCATION_KEY, locationString);
-
-        log.tracef("Updated authentication session location cache: IP=%s, Location=%s", ip, locationString);
     }
 }

--- a/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContextFactory.java
+++ b/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContextFactory.java
@@ -19,17 +19,19 @@ package io.github.mabartos.context.location;
 import io.github.mabartos.context.ip.IPAddress;
 import io.github.mabartos.spi.context.UserContextFactory;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.quarkus.runtime.configuration.Configuration;
 
+import java.util.Optional;
 import java.util.function.Function;
 
 public class IpApiLocationContextFactory implements UserContextFactory<LocationContext> {
     public static final String PROVIDER_ID = "ip-api-location-context";
+    private static final String API_TOKEN_PROPERTY = "location.ipapi.token";
 
     public static final Function<IPAddress, String> SERVICE_URL = ip -> {
-        String apiToken = System.getenv("KC_SPI_ADAPTIVE_AUTHN_IPAPI_TOKEN");
-        String tokenPart = (apiToken != null && !apiToken.isBlank())
-                ? "?token=" + apiToken
-                : "";
+        String tokenPart = getApiToken()
+                .map(token -> "?token=" + token)
+                .orElse("");
         return String.format("https://ipapi.co/%s/json%s", ip.toString(), tokenPart);
     };
 
@@ -46,5 +48,10 @@ public class IpApiLocationContextFactory implements UserContextFactory<LocationC
     @Override
     public Class<LocationContext> getUserContextClass() {
         return LocationContext.class;
+    }
+
+    static Optional<String> getApiToken() {
+        return Configuration.getOptionalValue(API_TOKEN_PROPERTY)
+                .filter(token -> !token.isBlank());
     }
 }

--- a/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContextFactory.java
+++ b/core/src/main/java/io/github/mabartos/context/location/IpApiLocationContextFactory.java
@@ -24,7 +24,14 @@ import java.util.function.Function;
 
 public class IpApiLocationContextFactory implements UserContextFactory<LocationContext> {
     public static final String PROVIDER_ID = "ip-api-location-context";
-    public static final Function<IPAddress, String> SERVICE_URL = ip -> String.format("https://ipapi.co/%s/json", ip.toString());
+
+    public static final Function<IPAddress, String> SERVICE_URL = ip -> {
+        String apiToken = System.getenv("KC_SPI_ADAPTIVE_AUTHN_IPAPI_TOKEN");
+        String tokenPart = (apiToken != null && !apiToken.isBlank())
+                ? "?token=" + apiToken
+                : "";
+        return String.format("https://ipapi.co/%s/json%s", ip.toString(), tokenPart);
+    };
 
     @Override
     public IpApiLocationContext create(KeycloakSession session) {

--- a/core/src/main/java/io/github/mabartos/context/location/LocationCondition.java
+++ b/core/src/main/java/io/github/mabartos/context/location/LocationCondition.java
@@ -43,7 +43,6 @@ public class LocationCondition implements UserContextCondition, ConditionalAuthe
 
     @Override
     public boolean requiresUser() {
-        log.tracef("[requiresUser()] return false");
         return false;
     }
 

--- a/core/src/main/java/io/github/mabartos/context/location/LocationCondition.java
+++ b/core/src/main/java/io/github/mabartos/context/location/LocationCondition.java
@@ -19,6 +19,7 @@ package io.github.mabartos.context.location;
 import io.github.mabartos.context.UserContexts;
 import io.github.mabartos.spi.condition.Operation;
 import io.github.mabartos.spi.condition.UserContextCondition;
+import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.authenticators.conditional.ConditionalAuthenticator;
 import org.keycloak.models.AuthenticatorConfigModel;
@@ -31,6 +32,7 @@ import java.util.List;
  * Condition for checking location properties
  */
 public class LocationCondition implements UserContextCondition, ConditionalAuthenticator {
+    private static final Logger log = Logger.getLogger(LocationCondition.class);
     private final LocationContext locationContext;
     private final List<Operation<LocationContext>> rules;
 
@@ -41,13 +43,19 @@ public class LocationCondition implements UserContextCondition, ConditionalAuthe
 
     @Override
     public boolean requiresUser() {
+        log.tracef("[requiresUser()] return false");
         return false;
     }
 
     @Override
     public boolean matchCondition(AuthenticationFlowContext context) {
+        log.tracef("[matchCondition()] start");
+
         AuthenticatorConfigModel authConfig = context.getAuthenticatorConfig();
-        if (authConfig == null) return false;
+        if (authConfig == null) {
+            log.tracef("[matchCondition()] authConfig is null, return false");
+            return false;
+        }
 
         var config = authConfig.getConfig();
 
@@ -55,7 +63,10 @@ public class LocationCondition implements UserContextCondition, ConditionalAuthe
         var countryOperation = config.get(LocationConditionFactory.COUNTRY_LIST_CONFIG);
         var countryValue = config.get(LocationConditionFactory.COUNTRY_VALUE_CONFIG);
 
+        log.tracef("[matchCondition()] countryOperation=%s & countryValue=%s", countryOperation, countryValue);
+
         if (StringUtil.isBlank(countryOperation) || StringUtil.isBlank(countryValue)) {
+            log.tracef("[matchCondition()] countryOperation or countryValue is blank, return false");
             return false;
         }
 
@@ -63,6 +74,7 @@ public class LocationCondition implements UserContextCondition, ConditionalAuthe
         boolean countryMatches = rules.stream()
                 .filter(f -> f.getText().equals(countryOperation))
                 .allMatch(f -> f.match(context.getRealm(), locationContext, countryValue));
+        log.tracef("[matchCondition()] countryMatches result: %s", countryMatches);
 
         if (!countryMatches) {
             return false;
@@ -72,12 +84,18 @@ public class LocationCondition implements UserContextCondition, ConditionalAuthe
         var cityOperation = config.get(LocationConditionFactory.CITY_LIST_CONFIG);
         var cityValue = config.get(LocationConditionFactory.CITY_VALUE_CONFIG);
 
+        log.tracef("[matchCondition()] cityOperation=%s & cityValue=%s", cityOperation, cityValue);
+
         if (StringUtil.isNotBlank(cityOperation) && StringUtil.isNotBlank(cityValue)) {
-            return rules.stream()
+            boolean cityMatches = rules.stream()
                     .filter(f -> f.getText().equals(cityOperation))
                     .allMatch(f -> f.match(context.getRealm(), locationContext, cityValue));
+
+            log.tracef("[matchCondition()] cityMatches result: %s", cityMatches);
+            return cityMatches;
         }
 
+        log.tracef("[matchCondition()] cityOperation or cityValue is blank, return true");
         return true;
     }
 }

--- a/core/src/main/java/io/github/mabartos/context/location/LocationConditionFactory.java
+++ b/core/src/main/java/io/github/mabartos/context/location/LocationConditionFactory.java
@@ -26,81 +26,98 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class LocationConditionFactory extends UserContextConditionFactory<LocationContext> {
-    public static final String PROVIDER_ID = "location-conditional-authenticator";
+        public static final String PROVIDER_ID = "location-conditional-authenticator";
 
-    public static final String COUNTRY_LIST_CONFIG = "countryListConfig";
-    public static final String COUNTRY_VALUE_CONFIG = "countryValueConfig";
+        public static final String COUNTRY_LIST_CONFIG = "countryListConfig";
+        public static final String COUNTRY_VALUE_CONFIG = "countryValueConfig";
 
-    public static final String CITY_LIST_CONFIG = "cityListConfig";
-    public static final String CITY_VALUE_CONFIG = "cityValueConfig";
+        public static final String CITY_LIST_CONFIG = "cityListConfig";
+        public static final String CITY_VALUE_CONFIG = "cityValueConfig";
 
-    public static final Operation<LocationContext> COUNTRY_IS = new Operation<>("COUNTRY_EQ", "country is", (realm, location, val) -> location.getData(realm).map(LocationData::getCountry).filter(f -> f.equals(val)).isPresent());
-    public static final Operation<LocationContext> COUNTRY_IS_NOT = new Operation<>("COUNTRY_NEQ", "country is not", (realm, location, val) -> location.getData(realm).map(LocationData::getCountry).filter(f -> f.equals(val)).isEmpty());
+        public static final Operation<LocationContext> COUNTRY_IS = new Operation<>("COUNTRY_EQ", "country is",
+                        (realm, location, vals) -> location.getData(realm).map(LocationData::getCountry)
+                                        .map(country -> vals.contains(country)).orElse(false),
+                        true);
+        public static final Operation<LocationContext> COUNTRY_IS_NOT = new Operation<>("COUNTRY_NEQ", "country is not",
+                        (realm, location, vals) -> location.getData(realm).map(LocationData::getCountry)
+                                        .map(country -> !vals.contains(country)).orElse(true),
+                        true);
 
-    public static final Operation<LocationContext> CITY_IS = new Operation<>("CITY_EQ", "city is", (realm, location, val) -> location.getData(realm).map(LocationData::getCity).filter(f -> f.equals(val)).isPresent());
-    public static final Operation<LocationContext> CITY_IS_NOT = new Operation<>("CITY_NEQ", "city is not", (realm, location, val) -> location.getData(realm).map(LocationData::getCity).filter(f -> f.equals(val)).isEmpty());
+        public static final Operation<LocationContext> CITY_IS = new Operation<>("CITY_EQ", "city is", (realm, location,
+                        vals) -> location.getData(realm).map(LocationData::getCity).map(city -> vals.contains(city))
+                                        .orElse(false),
+                        true);
+        public static final Operation<LocationContext> CITY_IS_NOT = new Operation<>("CITY_NEQ", "city is not", (realm,
+                        location, vals) -> location.getData(realm).map(LocationData::getCity)
+                                        .map(city -> !vals.contains(city)).orElse(true),
+                        true);
 
-    public LocationConditionFactory() {
-    }
+        public LocationConditionFactory() {
+        }
 
-    @Override
-    public LocationCondition create(KeycloakSession session) {
-        return new LocationCondition(session, getOperations());
-    }
+        @Override
+        public LocationCondition create(KeycloakSession session) {
+                return new LocationCondition(session, getOperations());
+        }
 
-    @Override
-    public List<Operation<LocationContext>> initOperations() {
-        return List.of(COUNTRY_IS, COUNTRY_IS_NOT, CITY_IS, CITY_IS_NOT);
-    }
+        @Override
+        public List<Operation<LocationContext>> initOperations() {
+                return List.of(COUNTRY_IS, COUNTRY_IS_NOT, CITY_IS, CITY_IS_NOT);
+        }
 
-    @Override
-    public String getDisplayType() {
-        return "Condition - Location";
-    }
+        @Override
+        public String getDisplayType() {
+                return "Condition - Location";
+        }
 
-    @Override
-    public String getHelpText() {
-        return "Condition matching Location attributes";
-    }
+        @Override
+        public String getHelpText() {
+                return "Condition matching Location attributes";
+        }
 
-    @Override
-    public List<ProviderConfigProperty> getConfigProperties() {
-        return ProviderConfigurationBuilder.create()
-                // Country
-                .property()
-                .name(COUNTRY_LIST_CONFIG)
-                .options(Stream.of(COUNTRY_IS, COUNTRY_IS_NOT).map(Operation::getText).toList())
-                .label(COUNTRY_LIST_CONFIG)
-                .helpText(COUNTRY_LIST_CONFIG + ".tooltip")
-                .type(ProviderConfigProperty.LIST_TYPE)
-                .add()
-                .property()
-                .name(COUNTRY_VALUE_CONFIG)
-                .label(COUNTRY_VALUE_CONFIG)
-                .helpText(COUNTRY_VALUE_CONFIG + ".tooltip")
-                .type(ProviderConfigProperty.STRING_TYPE)
-                .defaultValue("")
-                .add()
-                // City
-                .property()
-                .name(CITY_LIST_CONFIG)
-                .options(Stream.of(CITY_IS, CITY_IS_NOT).map(Operation::getText).toList())
-                .label(CITY_LIST_CONFIG)
-                .helpText(CITY_LIST_CONFIG + ".tooltip")
-                .type(ProviderConfigProperty.LIST_TYPE)
-                .add()
-                .property()
-                .name(CITY_VALUE_CONFIG)
-                .label(CITY_VALUE_CONFIG)
-                .helpText(CITY_VALUE_CONFIG + ".tooltip")
-                .type(ProviderConfigProperty.STRING_TYPE)
-                .defaultValue("")
-                .add()
-                .build();
-    }
+        @Override
+        public List<ProviderConfigProperty> getConfigProperties() {
+                return ProviderConfigurationBuilder.create()
 
-    @Override
-    public String getId() {
-        return PROVIDER_ID;
-    }
+                                // Country
+                                .property()
+                                .name(COUNTRY_LIST_CONFIG)
+                                .options(Stream.of(COUNTRY_IS, COUNTRY_IS_NOT).map(Operation::getText).toList())
+                                .label("Country condition")
+                                .helpText("whether the user's country must match or must not match the configured values.")
+                                .type(ProviderConfigProperty.LIST_TYPE)
+                                .add()
+
+                                .property()
+                                .name(COUNTRY_VALUE_CONFIG)
+                                .label("Countries")
+                                .helpText("Enter one or more country names, for example: France, Germany, Switzerland ...")
+                                .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
+                                .defaultValue(List.of())
+                                .add()
+
+                                // City
+                                .property()
+                                .name(CITY_LIST_CONFIG)
+                                .options(Stream.of(CITY_IS, CITY_IS_NOT).map(Operation::getText).toList())
+                                .label("City condition")
+                                .helpText("Defines whether the user's city must match or must not match the configured value.")
+                                .type(ProviderConfigProperty.LIST_TYPE)
+                                .add()
+
+                                .property()
+                                .name(CITY_VALUE_CONFIG)
+                                .label("City")
+                                .helpText("Enter one or more city names, for example: Paris, Berlin, Zurich ...")
+                                .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
+                                .defaultValue("")
+                                .add()
+
+                                .build();
+        }
+
+        @Override
+        public String getId() {
+                return PROVIDER_ID;
+        }
 }

--- a/core/src/main/java/io/github/mabartos/context/location/LocationConditionFactory.java
+++ b/core/src/main/java/io/github/mabartos/context/location/LocationConditionFactory.java
@@ -28,119 +28,119 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class LocationConditionFactory extends UserContextConditionFactory<LocationContext> {
-        public static final String PROVIDER_ID = "location-conditional-authenticator";
+    public static final String PROVIDER_ID = "location-conditional-authenticator";
 
-        public static final String COUNTRY_LIST_CONFIG = "countryListConfig";
-        public static final String COUNTRY_VALUE_CONFIG = "countryValueConfig";
+    public static final String COUNTRY_LIST_CONFIG = "countryListConfig";
+    public static final String COUNTRY_VALUE_CONFIG = "countryValueConfig";
 
-        public static final String CITY_LIST_CONFIG = "cityListConfig";
-        public static final String CITY_VALUE_CONFIG = "cityValueConfig";
+    public static final String CITY_LIST_CONFIG = "cityListConfig";
+    public static final String CITY_VALUE_CONFIG = "cityValueConfig";
 
-        public static final Operation<LocationContext> COUNTRY_IS = new Operation<>(
-                        "COUNTRY_" + DefaultOperation.ANY_OF.symbol(),
-                        "country is",
-                        LocationConditionFactory::matchesAnyCountry,
-                        true);
-        public static final Operation<LocationContext> COUNTRY_IS_NOT = new Operation<>(
-                        "COUNTRY_" + DefaultOperation.NONE_OF.symbol(),
-                        "country is not",
-                        (realm, location, vals) -> !matchesAnyCountry(realm, location, vals),
-                        true);
+    public static final Operation<LocationContext> COUNTRY_IS = new Operation<>(
+            "COUNTRY_" + DefaultOperation.ANY_OF.symbol(),
+            "country is",
+            LocationConditionFactory::matchesAnyCountry,
+            true);
+    public static final Operation<LocationContext> COUNTRY_IS_NOT = new Operation<>(
+            "COUNTRY_" + DefaultOperation.NONE_OF.symbol(),
+            "country is not",
+            (realm, location, vals) -> !matchesAnyCountry(realm, location, vals),
+            true);
 
-        public static final Operation<LocationContext> CITY_IS = new Operation<>(
-                        "CITY_" + DefaultOperation.ANY_OF.symbol(),
-                        "city is",
-                        LocationConditionFactory::matchesAnyCity,
-                        true);
-        public static final Operation<LocationContext> CITY_IS_NOT = new Operation<>(
-                        "CITY_" + DefaultOperation.NONE_OF.symbol(),
-                        "city is not",
-                        (realm, location, vals) -> !matchesAnyCity(realm, location, vals),
-                        true);
+    public static final Operation<LocationContext> CITY_IS = new Operation<>(
+            "CITY_" + DefaultOperation.ANY_OF.symbol(),
+            "city is",
+            LocationConditionFactory::matchesAnyCity,
+            true);
+    public static final Operation<LocationContext> CITY_IS_NOT = new Operation<>(
+            "CITY_" + DefaultOperation.NONE_OF.symbol(),
+            "city is not",
+            (realm, location, vals) -> !matchesAnyCity(realm, location, vals),
+            true);
 
-        public LocationConditionFactory() {
-        }
 
-        private static boolean matchesAnyCountry(org.keycloak.models.RealmModel realm, LocationContext location, List<String> countries) {
-                String detectedCountry = location.getData(realm).map(LocationData::getCountry).orElse("<unknown>");
-                return normalizeValues(countries).stream().anyMatch(detectedCountry::equals);
-        }
+    public LocationConditionFactory() {
+    }
 
-        private static boolean matchesAnyCity(org.keycloak.models.RealmModel realm, LocationContext location, List<String> cities) {
-                String detectedCity = location.getData(realm).map(LocationData::getCity).orElse("<unknown>");
-                return normalizeValues(cities).stream().anyMatch(detectedCity::equals);
-        }
+    private static boolean matchesAnyCountry(org.keycloak.models.RealmModel realm, LocationContext location, List<String> countries) {
+        String detectedCountry = location.getData(realm).map(LocationData::getCountry).orElse("<unknown>");
+        return normalizeValues(countries).stream().anyMatch(detectedCountry::equals);
+    }
 
-        private static List<String> normalizeValues(List<String> values) {
-                return values.stream()
-                                .map(value -> value != null ? value.trim() : null)
-                                .filter(StringUtil::isNotBlank)
-                                .toList();
-        }
+    private static boolean matchesAnyCity(org.keycloak.models.RealmModel realm, LocationContext location, List<String> cities) {
+        String detectedCity = location.getData(realm).map(LocationData::getCity).orElse("<unknown>");
+        return normalizeValues(cities).stream().anyMatch(detectedCity::equals);
+    }
 
-        @Override
-        public LocationCondition create(KeycloakSession session) {
-                return new LocationCondition(session, getOperations());
-        }
+    private static List<String> normalizeValues(List<String> values) {
+        return values.stream()
+                .map(value -> value != null ? value.trim() : null)
+                .filter(StringUtil::isNotBlank)
+                .toList();
+    }
 
-        @Override
-        public List<Operation<LocationContext>> initOperations() {
-                return List.of(COUNTRY_IS, COUNTRY_IS_NOT, CITY_IS, CITY_IS_NOT);
-        }
+    @Override
+    public LocationCondition create(KeycloakSession session) {
+        return new LocationCondition(session, getOperations());
+    }
 
-        @Override
-        public String getDisplayType() {
-                return "Condition - Location";
-        }
+    @Override
+    public List<Operation<LocationContext>> initOperations() {
+        return List.of(COUNTRY_IS, COUNTRY_IS_NOT, CITY_IS, CITY_IS_NOT);
+    }
 
-        @Override
-        public String getHelpText() {
-                return "Condition matching Location attributes";
-        }
+    @Override
+    public List<ProviderConfigProperty> getConfigProperties() {
+        return ProviderConfigurationBuilder.create()
+                // Country
+                .property()
+                .name(COUNTRY_LIST_CONFIG)
+                .options(Stream.of(COUNTRY_IS, COUNTRY_IS_NOT).map(Operation::getText).toList())
+                .label("Country condition")
+                .helpText("whether the user's country must match or must not match the configured values.")
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .add()
 
-        @Override
-        public List<ProviderConfigProperty> getConfigProperties() {
-                return ProviderConfigurationBuilder.create()
+                .property()
+                .name(COUNTRY_VALUE_CONFIG)
+                .label("Countries")
+                .helpText("Enter one or more country names, for example: France, Germany, Switzerland ...")
+                .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
+                .defaultValue(List.of())
+                .add()
 
-                                // Country
-                                .property()
-                                .name(COUNTRY_LIST_CONFIG)
-                                .options(Stream.of(COUNTRY_IS, COUNTRY_IS_NOT).map(Operation::getText).toList())
-                                .label("Country condition")
-                                .helpText("whether the user's country must match or must not match the configured values.")
-                                .type(ProviderConfigProperty.LIST_TYPE)
-                                .add()
+                // City
+                .property()
+                .name(CITY_LIST_CONFIG)
+                .options(Stream.of(CITY_IS, CITY_IS_NOT).map(Operation::getText).toList())
+                .label("City condition")
+                .helpText("Defines whether the user's city must match or must not match the configured value.")
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .add()
 
-                                .property()
-                                .name(COUNTRY_VALUE_CONFIG)
-                                .label("Countries")
-                                .helpText("Enter one or more country names, for example: France, Germany, Switzerland ...")
-                                .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
-                                .defaultValue(List.of())
-                                .add()
+                .property()
+                .name(CITY_VALUE_CONFIG)
+                .label("City")
+                .helpText("Enter one or more city names, for example: Paris, Berlin, Zurich ...")
+                .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
+                .defaultValue(List.of())
+                .add()
 
-                                // City
-                                .property()
-                                .name(CITY_LIST_CONFIG)
-                                .options(Stream.of(CITY_IS, CITY_IS_NOT).map(Operation::getText).toList())
-                                .label("City condition")
-                                .helpText("Defines whether the user's city must match or must not match the configured value.")
-                                .type(ProviderConfigProperty.LIST_TYPE)
-                                .add()
+                .build();
+    }
 
-                                .property()
-                                .name(CITY_VALUE_CONFIG)
-                                .label("City")
-                                .helpText("Enter one or more city names, for example: Paris, Berlin, Zurich ...")
-                                .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
-                                .defaultValue(List.of())
-                                .add()
+    @Override
+    public String getDisplayType() {
+        return "Condition - Location";
+    }
 
-                                .build();
-        }
+    @Override
+    public String getHelpText() {
+        return "Condition matching Location attributes";
+    }
 
-        @Override
-        public String getId() {
-                return PROVIDER_ID;
-        }
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
 }

--- a/core/src/main/java/io/github/mabartos/context/location/LocationConditionFactory.java
+++ b/core/src/main/java/io/github/mabartos/context/location/LocationConditionFactory.java
@@ -16,11 +16,13 @@
  */
 package io.github.mabartos.context.location;
 
+import io.github.mabartos.spi.condition.DefaultOperation;
 import io.github.mabartos.spi.condition.Operation;
 import io.github.mabartos.spi.condition.UserContextConditionFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.provider.ProviderConfigProperty;
 import org.keycloak.provider.ProviderConfigurationBuilder;
+import org.keycloak.utils.StringUtil;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -34,25 +36,46 @@ public class LocationConditionFactory extends UserContextConditionFactory<Locati
         public static final String CITY_LIST_CONFIG = "cityListConfig";
         public static final String CITY_VALUE_CONFIG = "cityValueConfig";
 
-        public static final Operation<LocationContext> COUNTRY_IS = new Operation<>("COUNTRY_EQ", "country is",
-                        (realm, location, vals) -> location.getData(realm).map(LocationData::getCountry)
-                                        .map(country -> vals.contains(country)).orElse(false),
+        public static final Operation<LocationContext> COUNTRY_IS = new Operation<>(
+                        "COUNTRY_" + DefaultOperation.ANY_OF.symbol(),
+                        "country is",
+                        LocationConditionFactory::matchesAnyCountry,
                         true);
-        public static final Operation<LocationContext> COUNTRY_IS_NOT = new Operation<>("COUNTRY_NEQ", "country is not",
-                        (realm, location, vals) -> location.getData(realm).map(LocationData::getCountry)
-                                        .map(country -> !vals.contains(country)).orElse(true),
+        public static final Operation<LocationContext> COUNTRY_IS_NOT = new Operation<>(
+                        "COUNTRY_" + DefaultOperation.NONE_OF.symbol(),
+                        "country is not",
+                        (realm, location, vals) -> !matchesAnyCountry(realm, location, vals),
                         true);
 
-        public static final Operation<LocationContext> CITY_IS = new Operation<>("CITY_EQ", "city is", (realm, location,
-                        vals) -> location.getData(realm).map(LocationData::getCity).map(city -> vals.contains(city))
-                                        .orElse(false),
+        public static final Operation<LocationContext> CITY_IS = new Operation<>(
+                        "CITY_" + DefaultOperation.ANY_OF.symbol(),
+                        "city is",
+                        LocationConditionFactory::matchesAnyCity,
                         true);
-        public static final Operation<LocationContext> CITY_IS_NOT = new Operation<>("CITY_NEQ", "city is not", (realm,
-                        location, vals) -> location.getData(realm).map(LocationData::getCity)
-                                        .map(city -> !vals.contains(city)).orElse(true),
+        public static final Operation<LocationContext> CITY_IS_NOT = new Operation<>(
+                        "CITY_" + DefaultOperation.NONE_OF.symbol(),
+                        "city is not",
+                        (realm, location, vals) -> !matchesAnyCity(realm, location, vals),
                         true);
 
         public LocationConditionFactory() {
+        }
+
+        private static boolean matchesAnyCountry(org.keycloak.models.RealmModel realm, LocationContext location, List<String> countries) {
+                String detectedCountry = location.getData(realm).map(LocationData::getCountry).orElse("<unknown>");
+                return normalizeValues(countries).stream().anyMatch(detectedCountry::equals);
+        }
+
+        private static boolean matchesAnyCity(org.keycloak.models.RealmModel realm, LocationContext location, List<String> cities) {
+                String detectedCity = location.getData(realm).map(LocationData::getCity).orElse("<unknown>");
+                return normalizeValues(cities).stream().anyMatch(detectedCity::equals);
+        }
+
+        private static List<String> normalizeValues(List<String> values) {
+                return values.stream()
+                                .map(value -> value != null ? value.trim() : null)
+                                .filter(StringUtil::isNotBlank)
+                                .toList();
         }
 
         @Override
@@ -110,7 +133,7 @@ public class LocationConditionFactory extends UserContextConditionFactory<Locati
                                 .label("City")
                                 .helpText("Enter one or more city names, for example: Paris, Berlin, Zurich ...")
                                 .type(ProviderConfigProperty.MULTIVALUED_STRING_TYPE)
-                                .defaultValue("")
+                                .defaultValue(List.of())
                                 .add()
 
                                 .build();

--- a/core/src/main/resources/META-INF/services/io.github.mabartos.spi.context.UserContextFactory
+++ b/core/src/main/resources/META-INF/services/io.github.mabartos.spi.context.UserContextFactory
@@ -2,6 +2,7 @@ io.github.mabartos.context.device.DeviceRepresentationContextFactory
 io.github.mabartos.context.user.KcUserRoleContextFactory
 io.github.mabartos.context.ip.proxy.ProxyIpAddressContextFactory
 io.github.mabartos.context.location.AuthnSessionLocationContextFactory
+io.github.mabartos.context.location.GlobalCacheLocationContextFactory
 io.github.mabartos.context.location.IpApiLocationContextFactory
 io.github.mabartos.context.ip.client.DeviceIpAddressContextFactory
 io.github.mabartos.context.ip.client.HeaderIpAddressContextFactory

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -36,10 +36,10 @@ recaptcha.project.id=${RECAPTCHA_PROJECT_ID}
 recaptcha.project.api.key=${RECAPTCHA_PROJECT_API_KEY}
 
 # testing
-ip.address.testing.random.enabled=${KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP:false}
-ip.address.testing.value=${KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP_ADRESSES:}
+ip.address.testing.random.enabled=${KC_AA_TESTING_RANDOM_IP_ENABLED:false}
+ip.address.testing.value=${KC_AA_TESTING_IP_VALUE:}
 
 # location
-location.ipapi.token=${KC_SPI_ADAPTIVE_AUTHN_IPAPI_TOKEN:}
-location.global-cache.ttl=${LOCATION_GLOBAL_CACHE_TTL:PT24H}
-location.global-cache.maximum-size=${LOCATION_GLOBAL_CACHE_MAXIMUM_SIZE:10000}
+location.ipapi.token=${KC_AA_IPAPI_TOKEN:}
+location.global-cache.ttl=${KC_AA_LOCATION_GLOBAL_CACHE_TTL:PT24H}
+location.global-cache.maximum-size=${KC_AA_LOCATION_GLOBAL_CACHE_MAXIMUM_SIZE:10000}

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -36,4 +36,10 @@ recaptcha.project.id=${RECAPTCHA_PROJECT_ID}
 recaptcha.project.api.key=${RECAPTCHA_PROJECT_API_KEY}
 
 # testing
-ip.address.use.testing=${IP_ADDRESS_USE_TESTING}:false
+ip.address.testing.random.enabled=${KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP:false}
+ip.address.testing.value=${KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP_ADRESSES:}
+
+# location
+location.ipapi.token=${KC_SPI_ADAPTIVE_AUTHN_IPAPI_TOKEN:}
+location.global-cache.ttl=${LOCATION_GLOBAL_CACHE_TTL:PT24H}
+location.global-cache.maximum-size=${LOCATION_GLOBAL_CACHE_MAXIMUM_SIZE:10000}

--- a/core/src/test/java/io/github/mabartos/context/location/LocationCityOperationTest.java
+++ b/core/src/test/java/io/github/mabartos/context/location/LocationCityOperationTest.java
@@ -1,0 +1,209 @@
+package io.github.mabartos.context.location;
+
+import io.github.mabartos.spi.condition.Operation;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for city-based operations CITY_IS and CITY_IS_NOT.
+ */
+public class LocationCityOperationTest {
+
+    /* Tests 'CITY_IS' single-value */
+    @Test
+    public void testCityIsSingleValueMatch() {
+        var context = new StaticLocationContext("Paris");
+        RealmModel realm = null;
+
+        boolean result = LocationConditionFactory.CITY_IS.match(realm, context, "Paris");
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void testCityIsSingleValueDontMatch() {
+        var context = new StaticLocationContext("Paris");
+        RealmModel realm = null;
+
+        boolean result = LocationConditionFactory.CITY_IS.match(realm, context, "Lyon");
+
+        assertThat(result, is(false));
+    }
+
+    /* Tests 'CITY_IS' multi-values */
+    @Test
+    public void testCityIsMultiValuesMatch() {
+        var context = new StaticLocationContext("Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Lyon" + delimiter + "Paris" + delimiter + "Marseille";
+
+        boolean result = LocationConditionFactory.CITY_IS.match(realm, context, values);
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void testCityIsMultiValuesDontMatch() {
+        var context = new StaticLocationContext("Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Lyon" + delimiter + "Marseille";
+
+        boolean result = LocationConditionFactory.CITY_IS.match(realm, context, values);
+
+        assertThat(result, is(false));
+    }
+
+    /* Tests 'CITY_IS_NOT' single-value */
+    @Test
+    public void testCityIsNotSingleValueMatch() {
+        var context = new StaticLocationContext("Paris");
+        RealmModel realm = null;
+
+        boolean result = LocationConditionFactory.CITY_IS_NOT.match(realm, context, "Lyon");
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void testCityIsNotSingleValuesDontMatch() {
+        var context = new StaticLocationContext("Paris");
+        RealmModel realm = null;
+
+        boolean result = LocationConditionFactory.CITY_IS_NOT.match(realm, context, "Paris");
+
+        assertThat(result, is(false));
+    }
+
+    /* Tests 'CITY_IS_NOT' multi-values */
+    @Test
+    public void testCityIsNotMultiValuesMatch() {
+        var context = new StaticLocationContext("Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Lyon" + delimiter + "Marseille";
+
+        boolean result = LocationConditionFactory.CITY_IS_NOT.match(realm, context, values);
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void testCityIsNotMultiValuesDontMatch() {
+        var context = new StaticLocationContext("Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Lyon" + delimiter + "Paris";
+
+        boolean result = LocationConditionFactory.CITY_IS_NOT.match(realm, context, values);
+
+        assertThat(result, is(false));
+    }
+
+    /**
+     * Simple {@link LocationContext} implementation for tests that always returns
+     * a static {@link LocationData} instance with the given city.
+     */
+    static class StaticLocationContext extends LocationContext {
+
+        private final LocationData data;
+
+        StaticLocationContext(String city) {
+            super((KeycloakSession) null);
+            this.data = new StaticLocationData(city);
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return true;
+        }
+
+        @Override
+        public Optional<LocationData> initData(RealmModel realm) {
+            return Optional.of(data);
+        }
+
+        @Override
+        public Optional<LocationData> getData(RealmModel realm) {
+            return Optional.of(data);
+        }
+
+        @Override
+        public Optional<LocationData> getData(RealmModel realm, org.keycloak.models.UserModel knownUser) {
+            return Optional.of(data);
+        }
+    }
+
+    /**
+     * Simple {@link LocationData} implementation for tests.
+     */
+    static class StaticLocationData implements LocationData {
+
+        private final String city;
+
+        StaticLocationData(String city) {
+            this.city = city;
+        }
+
+        @Override
+        public String getCity() {
+            return city;
+        }
+
+        @Override
+        public String getRegion() {
+            return null;
+        }
+
+        @Override
+        public String getRegionCode() {
+            return null;
+        }
+
+        @Override
+        public String getCountry() {
+            return null;
+        }
+
+        @Override
+        public String getContinent() {
+            return null;
+        }
+
+        @Override
+        public String getPostalCode() {
+            return null;
+        }
+
+        @Override
+        public Double getLatitude() {
+            return null;
+        }
+
+        @Override
+        public Double getLongitude() {
+            return null;
+        }
+
+        @Override
+        public String getTimezone() {
+            return null;
+        }
+
+        @Override
+        public String getCurrency() {
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/io/github/mabartos/context/location/LocationCityOperationTest.java
+++ b/core/src/test/java/io/github/mabartos/context/location/LocationCityOperationTest.java
@@ -63,6 +63,19 @@ public class LocationCityOperationTest {
         assertThat(result, is(false));
     }
 
+    @Test
+    public void testCityIsMultiValuesTrimmedMatch() {
+        var context = new StaticLocationContext("Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Lyon" + delimiter + " Paris " + delimiter + "Marseille";
+
+        boolean result = LocationConditionFactory.CITY_IS.match(realm, context, values);
+
+        assertThat(result, is(true));
+    }
+
     /* Tests 'CITY_IS_NOT' single-value */
     @Test
     public void testCityIsNotSingleValueMatch() {

--- a/core/src/test/java/io/github/mabartos/context/location/LocationCountryCityCombinationTest.java
+++ b/core/src/test/java/io/github/mabartos/context/location/LocationCountryCityCombinationTest.java
@@ -1,0 +1,317 @@
+package io.github.mabartos.context.location;
+
+import io.github.mabartos.spi.condition.Operation;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for combined evaluation of country + city operations.
+ *
+ * This mirrors how {@link LocationCondition} effectively evaluates config:
+ * country must match, and if city is specified, it must also match.
+ */
+public class LocationCountryCityCombinationTest {
+
+    /* '*_IS' single-value*/
+    @Test
+    public void testCountryAndCitySingleValueMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS.match(realm, context, "France");
+        boolean cityMatches = LocationConditionFactory.CITY_IS.match(realm, context, "Paris");
+
+        assertThat(countryMatches && cityMatches, is(true));
+    }
+
+    @Test
+    public void testCountryMatchCityDontMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS.match(realm, context, "France");
+        boolean cityMatches = LocationConditionFactory.CITY_IS.match(realm, context, "Lyon");
+
+        assertThat(countryMatches && cityMatches, is(false));
+    }
+
+    @Test
+    public void testCountryDontMatchCityMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS.match(realm, context, "Germany");
+        boolean cityMatches = LocationConditionFactory.CITY_IS.match(realm, context, "Paris");
+
+        assertThat(countryMatches && cityMatches, is(false));
+    }
+
+    /* '*_IS' multi-values */
+    @Test
+    public void testCountryAndCityMultiValuesMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String countryValues = "Germany" + delimiter + "France" + delimiter + "Spain";
+        String cityValues = "Lyon" + delimiter + "Paris" + delimiter + "Marseille";
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS.match(realm, context, countryValues);
+        boolean cityMatches = LocationConditionFactory.CITY_IS.match(realm, context, cityValues);
+
+        assertThat(countryMatches && cityMatches, is(true));
+    }
+
+    @Test
+    public void testCountryMultiValuesMatchCityMultiValuesDontMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String countryValues = "Germany" + delimiter + "France" + delimiter + "Spain";
+        String cityValues = "Lyon" + delimiter + "Marseille";
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS.match(realm, context, countryValues);
+        boolean cityMatches = LocationConditionFactory.CITY_IS.match(realm, context, cityValues);
+
+        assertThat(countryMatches && cityMatches, is(false));
+    }
+
+    @Test
+    public void testCountryMultiValuesDontMatchCityMultiValuesMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String countryValues = "Germany" + delimiter + "Spain";
+        String cityValues = "Lyon" + delimiter + "Paris" + delimiter + "Marseille";
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS.match(realm, context, countryValues);
+        boolean cityMatches = LocationConditionFactory.CITY_IS.match(realm, context, cityValues);
+
+        assertThat(countryMatches && cityMatches, is(false));
+    }
+
+    /* '*_IS_NOT' single-value */
+    @Test
+    public void testCountryAndCityIsNotSingleValueMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, "Germany");
+        boolean cityMatches = LocationConditionFactory.CITY_IS_NOT.match(realm, context, "Lyon");
+
+        assertThat(countryMatches && cityMatches, is(true));
+    }
+
+    @Test
+    public void testCountryIsNotMatchCityIsNotDontMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, "Germany");
+        boolean cityMatches = LocationConditionFactory.CITY_IS_NOT.match(realm, context, "Paris");
+
+        assertThat(countryMatches && cityMatches, is(false));
+    }
+
+    @Test
+    public void testCountryIsNotDontMatchCityIsNotMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, "France");
+        boolean cityMatches = LocationConditionFactory.CITY_IS_NOT.match(realm, context, "Lyon");
+
+        assertThat(countryMatches && cityMatches, is(false));
+    }
+
+    /* '*_IS_NOT' multi-values */
+    @Test
+    public void testCountryAndCityIsNotMultiValuesMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String countryValues = "Germany" + delimiter + "Spain";
+        String cityValues = "Lyon" + delimiter + "Marseille";
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, countryValues);
+        boolean cityMatches = LocationConditionFactory.CITY_IS_NOT.match(realm, context, cityValues);
+
+        assertThat(countryMatches && cityMatches, is(true));
+    }
+
+    @Test
+    public void testCountryIsNotMultiValuesMatchCityIsNotMultiValuesDontMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String countryValues = "Germany" + delimiter + "Spain";
+        String cityValues = "Lyon" + delimiter + "Paris" + delimiter + "Marseille";
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, countryValues);
+        boolean cityMatches = LocationConditionFactory.CITY_IS_NOT.match(realm, context, cityValues);
+
+        assertThat(countryMatches && cityMatches, is(false));
+    }
+
+    @Test
+    public void testCountryIsNotMultiValuesDontMatchCityIsNotMultiValuesMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String countryValues = "Germany" + delimiter + "France" + delimiter + "Spain";
+        String cityValues = "Lyon" + delimiter + "Marseille";
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, countryValues);
+        boolean cityMatches = LocationConditionFactory.CITY_IS_NOT.match(realm, context, cityValues);
+
+        assertThat(countryMatches && cityMatches, is(false));
+    }
+
+    /* Mix '*_IS'/'*_IS_NOT' single-value*/
+    @Test
+    public void testCountryIsNotMatchAndCityIsMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, "Germany");
+        boolean cityMatches = LocationConditionFactory.CITY_IS.match(realm, context, "Paris");
+
+        assertThat(countryMatches && cityMatches, is(true));
+    }
+
+    @Test
+    public void testCountryMultiValuesDontMatchCitySingleValueMatch() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String countryValues = "Germany" + delimiter + "France";
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, countryValues);
+        boolean cityMatches = LocationConditionFactory.CITY_IS.match(realm, context, "Paris");
+
+        assertThat(countryMatches && cityMatches, is(false));
+    }
+
+    @Test
+    public void testCountryAndCityBothMultiValueMatches() {
+        var context = new StaticLocationContext("France", "Paris");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String countryValues = "Germany" + delimiter + "France" + delimiter + "Spain";
+        String cityValues = "Lyon" + delimiter + "Paris" + delimiter + "Marseille";
+
+        boolean countryMatches = LocationConditionFactory.COUNTRY_IS.match(realm, context, countryValues);
+        boolean cityMatches = LocationConditionFactory.CITY_IS.match(realm, context, cityValues);
+
+        assertThat(countryMatches && cityMatches, is(true));
+    }
+
+    /**
+     * Simple {@link LocationContext} implementation for tests that always returns
+     * a static {@link LocationData} instance with the given country and city.
+     *
+     * Overrides getData to avoid requiring a real {@link KeycloakSession}.
+     */
+    static class StaticLocationContext extends LocationContext {
+
+        private final LocationData data;
+
+        StaticLocationContext(String country, String city) {
+            super((KeycloakSession) null);
+            this.data = new StaticLocationData(country, city);
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return true;
+        }
+
+        @Override
+        public Optional<LocationData> initData(RealmModel realm) {
+            return Optional.of(data);
+        }
+
+        @Override
+        public Optional<LocationData> getData(RealmModel realm) {
+            return Optional.of(data);
+        }
+
+        @Override
+        public Optional<LocationData> getData(RealmModel realm, org.keycloak.models.UserModel knownUser) {
+            return Optional.of(data);
+        }
+    }
+
+    static class StaticLocationData implements LocationData {
+        private final String country;
+        private final String city;
+
+        StaticLocationData(String country, String city) {
+            this.country = country;
+            this.city = city;
+        }
+
+        @Override
+        public String getCity() {
+            return city;
+        }
+
+        @Override
+        public String getRegion() {
+            return null;
+        }
+
+        @Override
+        public String getRegionCode() {
+            return null;
+        }
+
+        @Override
+        public String getCountry() {
+            return country;
+        }
+
+        @Override
+        public String getContinent() {
+            return null;
+        }
+
+        @Override
+        public String getPostalCode() {
+            return null;
+        }
+
+        @Override
+        public Double getLatitude() {
+            return null;
+        }
+
+        @Override
+        public Double getLongitude() {
+            return null;
+        }
+
+        @Override
+        public String getTimezone() {
+            return null;
+        }
+
+        @Override
+        public String getCurrency() {
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/io/github/mabartos/context/location/LocationCountryOperationTest.java
+++ b/core/src/test/java/io/github/mabartos/context/location/LocationCountryOperationTest.java
@@ -1,0 +1,211 @@
+package io.github.mabartos.context.location;
+
+import io.github.mabartos.context.location.LocationCountryOperationTest.StaticLocationContext;
+import io.github.mabartos.context.location.LocationCountryOperationTest.StaticLocationData;
+import io.github.mabartos.spi.condition.Operation;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Tests for country-based operations COUNTRY_IS and COUNTRY_IS_NOT.
+ */
+public class LocationCountryOperationTest {
+
+    /* Tests 'COUNTRY_IS' single-value */
+    @Test
+    public void testCountryIsSingleValueMatches() {
+        var context = new StaticLocationContext("France");
+        RealmModel realm = null;
+
+        boolean result = LocationConditionFactory.COUNTRY_IS.match(realm, context, "France");
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void testCountryIsSingleValueDontMatch() {
+        var context = new StaticLocationContext("France");
+        RealmModel realm = null;
+
+        boolean result = LocationConditionFactory.COUNTRY_IS.match(realm, context, "Germany");
+
+        assertThat(result, is(false));
+    }
+
+    /* Tests 'COUNTRY_IS' multi-values */
+    @Test
+    public void testCountryIsMultiValuesMatch() {
+        var context = new StaticLocationContext("France");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Germany" + delimiter + "France" + delimiter + "Spain";
+
+        boolean result = LocationConditionFactory.COUNTRY_IS.match(realm, context, values);
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void testCountryIsMultiValuesDontMatch() {
+        var context = new StaticLocationContext("France");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Germany" + delimiter + "Spain";
+
+        boolean result = LocationConditionFactory.COUNTRY_IS.match(realm, context, values);
+
+        assertThat(result, is(false));
+    }
+
+    /* Tests 'COUNTRY_IS_NOT' single-value */
+    @Test
+    public void testCountryIsNotSingleValueMatch() {
+        var context = new StaticLocationContext("France");
+        RealmModel realm = null;
+
+        boolean result = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, "France");
+
+        assertThat(result, is(false));
+    }
+    
+    @Test
+    public void testCountryIsNotSingleValueDontMatch() {
+        var context = new StaticLocationContext("France");
+        RealmModel realm = null;
+
+        boolean result = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, "Germany");
+
+        assertThat(result, is(true));
+    }
+
+    /* Tests 'COUNTRY_IS_NOT' multi-values */
+    @Test
+    public void testCountryIsNotMultiValuesMatch() {
+        var context = new StaticLocationContext("France");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Germany" + delimiter + "France";
+
+        boolean result = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, values);
+
+        assertThat(result, is(false));
+    }
+    
+    @Test
+    public void testCountryIsNotMultiValuesDontMatch() {
+        var context = new StaticLocationContext("France");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Germany" + delimiter + "Spain";
+
+        boolean result = LocationConditionFactory.COUNTRY_IS_NOT.match(realm, context, values);
+
+        assertThat(result, is(true));
+    }
+
+    /**
+     * Simple {@link LocationContext} implementation for tests that always returns
+     * a static {@link LocationData} instance with the given country.
+     */
+    static class StaticLocationContext extends LocationContext {
+
+        private final LocationData data;
+
+        StaticLocationContext(String country) {
+            super((KeycloakSession) null);
+            this.data = new StaticLocationData(country);
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return true;
+        }
+
+        @Override
+        public Optional<LocationData> initData(RealmModel realm) {
+            return Optional.of(data);
+        }
+
+        @Override
+        public Optional<LocationData> getData(RealmModel realm) {
+            return Optional.of(data);
+        }
+
+        @Override
+        public Optional<LocationData> getData(RealmModel realm, org.keycloak.models.UserModel knownUser) {
+            return Optional.of(data);
+        }
+    }
+
+    /**
+     * Simple {@link LocationData} implementation for tests.
+     */
+    static class StaticLocationData implements LocationData {
+
+        private final String country;
+
+        StaticLocationData(String country) {
+            this.country = country;
+        }
+
+        @Override
+        public String getCity() {
+            return null;
+        }
+
+        @Override
+        public String getRegion() {
+            return null;
+        }
+
+        @Override
+        public String getRegionCode() {
+            return null;
+        }
+
+        @Override
+        public String getCountry() {
+            return country;
+        }
+
+        @Override
+        public String getContinent() {
+            return null;
+        }
+
+        @Override
+        public String getPostalCode() {
+            return null;
+        }
+
+        @Override
+        public Double getLatitude() {
+            return null;
+        }
+
+        @Override
+        public Double getLongitude() {
+            return null;
+        }
+
+        @Override
+        public String getTimezone() {
+            return null;
+        }
+
+        @Override
+        public String getCurrency() {
+            return null;
+        }
+    }
+}

--- a/core/src/test/java/io/github/mabartos/context/location/LocationCountryOperationTest.java
+++ b/core/src/test/java/io/github/mabartos/context/location/LocationCountryOperationTest.java
@@ -65,6 +65,19 @@ public class LocationCountryOperationTest {
         assertThat(result, is(false));
     }
 
+    @Test
+    public void testCountryIsMultiValuesTrimmedMatch() {
+        var context = new StaticLocationContext("France");
+        RealmModel realm = null;
+
+        String delimiter = Operation.DEFAULT_MULTI_VALUES_DELIMITER;
+        String values = "Germany" + delimiter + " France " + delimiter + "Spain";
+
+        boolean result = LocationConditionFactory.COUNTRY_IS.match(realm, context, values);
+
+        assertThat(result, is(true));
+    }
+
     /* Tests 'COUNTRY_IS_NOT' single-value */
     @Test
     public void testCountryIsNotSingleValueMatch() {

--- a/tests/src/test/java/io/github/mabartos/ChainedUserContextTest.java
+++ b/tests/src/test/java/io/github/mabartos/ChainedUserContextTest.java
@@ -22,6 +22,10 @@ import io.github.mabartos.context.ip.client.DeviceIpAddressContext;
 import io.github.mabartos.context.ip.client.HeaderIpAddressContext;
 import io.github.mabartos.context.ip.client.IpAddressContext;
 import io.github.mabartos.context.ip.client.TestIpAddressContext;
+import io.github.mabartos.context.location.AuthnSessionLocationContext;
+import io.github.mabartos.context.location.GlobalCacheLocationContext;
+import io.github.mabartos.context.location.IpApiLocationContext;
+import io.github.mabartos.context.location.LocationContext;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.keycloak.models.KeycloakSession;
@@ -130,6 +134,24 @@ public class ChainedUserContextTest {
                 // This should throw because NonExistentContext doesn't have any registered providers
                 UserContexts.getContext(session, NonExistentContext.class);
             });
+        });
+    }
+
+    @Test
+    @Order(4)
+    public void locationContextDelegatesByCachePriority() {
+        runOnServer.run(session -> {
+            LocationContext context = UserContexts.getContext(session, LocationContext.class);
+            assertNotNull(context);
+            assertThat(context.getClass(), is(AuthnSessionLocationContext.class));
+
+            var firstDelegate = context.getDelegate();
+            assertThat(firstDelegate.isPresent(), is(true));
+            assertThat(firstDelegate.get().getClass(), is(GlobalCacheLocationContext.class));
+
+            var secondDelegate = firstDelegate.get().getDelegate();
+            assertThat(secondDelegate.isPresent(), is(true));
+            assertThat(secondDelegate.get().getClass(), is(IpApiLocationContext.class));
         });
     }
 


### PR DESCRIPTION
## Summary

This PR fixes the GeoIP location conditions for `country is` / `country is not` and `city is` / `city is not`, and adds unit tests to cover the expected behavior.

It also introduces a JVM-wide cache for IP → location resolution to avoid repeated lookups during authentication, and adds support for passing an API token to `ipapi.co` via environment variable.

Additionally, it makes it easier to debug location-based flows locally by allowing the resolved IP to be overridden or randomized through environment variables, which is especially convenient when running Keycloak in Docker.

Fixes mabartos/keycloak-adaptive-authn#26

## Details

- Fix country and city condition evaluation so that:
  - `country is` / `city is` correctly match against the resolved `LocationData`
  - `country is not` / `city is not` behave as the logical negation, including for multi-valued configuration
- Add a global JVM cache for IP → location lookups to reduce network calls and improve latency
- Add support for `ipapi.co` token via:
  - `KC_SPI_ADAPTIVE_AUTHN_IPAPI_TOKEN` (e.g. `-e KC_SPI_ADAPTIVE_AUTHN_IPAPI_TOKEN=...` in Docker)
- Add debug helpers to override the client IP used for GeoIP lookups:
  - `KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP`: when set to true, uses a random IP from the sample list (either the built‑in one or the one provided below).
  - `KC_SPI_ADAPTATIVE_AUTHN_DEBUG_RANDOM_IP_ADRESSES`: overrides the built‑in sample list with a comma‑separated list of IPs (e.g. 1.2.3.4,5.6.7.8).
  

## Testing

- Added `LocationCountryOperationTest` for:
  - `COUNTRY_IS` and `COUNTRY_IS_NOT` with single- and multi-value configuration
- Added `LocationCityOperationTest` for:
  - `CITY_IS` and `CITY_IS_NOT` with single- and multi-value configuration
- Added `LocationCountryCityCombinationTest` to cover combined country + city evaluation

All new tests pass and reproduce the scenarios where country/city conditions previously behaved incorrectly.