### PR TITLE
fix(tests): replace RealmConfigBuilder with RealmBuilder from keycloak-test-framework-builders

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,12 +13,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - keycloak-version: nightly
-            extra-args: ""
+          - keycloak-version: 999.0.0-SNAPSHOT
+            build-args: ""
+            test-args: -Dkeycloak.version=999.0.0-SNAPSHOT
           - keycloak-version: 26.5.7
-            extra-args: -Pdist-maven -Dkeycloak.version=26.5.7
+            # realm.source=released on build too: avoids resolving builders (nightly-only) at ${keycloak.version}
+            build-args: -Pdist-maven -Dkeycloak.version=26.5.7 -Dkeycloak.test.realm.source=released
+            # 26.5.7 test-framework cannot resolve remote-providers, fixed in 26.6.0+ (https://github.com/keycloak/keycloak/pull/45636)
+            test-args: -Dkeycloak.version=26.6.0 -Dkeycloak.test.realm.source=released
           - keycloak-version: 26.6.0
-            extra-args: -Pdist-maven -Dkeycloak.version=26.6.0
+            build-args: -Pdist-maven -Dkeycloak.version=26.6.0 -Dkeycloak.test.realm.source=released
+            test-args: -Dkeycloak.version=26.6.0 -Dkeycloak.test.realm.source=released
 
     name: Keycloak ${{ matrix.keycloak-version }}
     steps:
@@ -32,13 +37,14 @@ jobs:
         cache: maven
 
     - name: Build extension
-      run: ./mvnw clean install -DskipTests -Pbuild-distribution ${{ matrix.extra-args }}
+      # maven.test.skip (not skipTests): tests compile later with test-args (version may differ from build on 26.5.7)
+      run: ./mvnw clean install -Dmaven.test.skip=true -Pbuild-distribution ${{ matrix.build-args }}
 
     - name: Test execute 'build' command
-      run: ./mvnw -f core exec:exec@build
+      run: ./mvnw -f core exec:exec@build ${{ matrix.test-args }}
 
     - name: Unit tests
-      run: ./mvnw -f core test
+      run: ./mvnw -f core test ${{ matrix.test-args }}
 
     - name: Integration tests
-      run: ./mvnw -f tests test
+      run: ./mvnw -f tests test ${{ matrix.test-args }}

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,9 @@
         <keycloak.dist.version>${keycloak.version}</keycloak.dist.version>
         <keycloak.github.tag>nightly</keycloak.github.tag>
         <keycloak.github.url>https://github.com/keycloak/keycloak/releases/download/${keycloak.github.tag}/keycloak-${keycloak.dist.version}.zip</keycloak.github.url>
+
+        <!-- Integration tests: java-nightly (RealmBuilder) or java-released (RealmConfigBuilder); override with -Dkeycloak.test.realm.source=released -->
+        <keycloak.test.realm.source>nightly</keycloak.test.realm.source>
     </properties>
 
     <dependencyManagement>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -53,6 +53,11 @@
             <artifactId>keycloak-test-framework-remote</artifactId>
             <version>${keycloak.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.keycloak.testframework</groupId>
+            <artifactId>keycloak-test-framework-builders</artifactId>
+            <version>${keycloak.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -53,15 +53,33 @@
             <artifactId>keycloak-test-framework-remote</artifactId>
             <version>${keycloak.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.keycloak.testframework</groupId>
-            <artifactId>keycloak-test-framework-builders</artifactId>
-            <version>${keycloak.version}</version>
-        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <!--
+              Realm config: java-${keycloak.test.realm.source} (default nightly).
+              Stable Keycloak: pass -Dkeycloak.test.realm.source=released with -Dkeycloak.version=26.6.0 (or 26.5.7).
+            -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
+                <executions>
+                    <execution>
+                        <id>add-realm-config-test-source</id>
+                        <phase>generate-test-sources</phase>
+                        <goals>
+                            <goal>add-test-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.basedir}/src/test/java-${keycloak.test.realm.source}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
@@ -76,5 +94,25 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- keycloak-test-framework-builders: SNAPSHOT / java-nightly only (keycloak/keycloak#48315) -->
+        <profile>
+            <id>keycloak-nightly-test-framework</id>
+            <activation>
+                <property>
+                    <name>keycloak.test.realm.source</name>
+                    <value>nightly</value>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.keycloak.testframework</groupId>
+                    <artifactId>keycloak-test-framework-builders</artifactId>
+                    <version>${keycloak.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/tests/src/test/java-nightly/io/github/mabartos/AdaptiveRealmConfig.java
+++ b/tests/src/test/java-nightly/io/github/mabartos/AdaptiveRealmConfig.java
@@ -1,0 +1,33 @@
+package io.github.mabartos;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testframework.realm.RealmBuilder;
+import org.keycloak.testframework.realm.RealmConfig;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Realm config for Keycloak nightly ({@code 999.0.0-SNAPSHOT}) using {@link RealmBuilder}
+ * after <a href="https://github.com/keycloak/keycloak/pull/48315">keycloak#48315</a>.
+ */
+public class AdaptiveRealmConfig implements RealmConfig {
+    public static final String REALM_JSON_NAME = "test-adaptive-realm.json";
+
+    @Override
+    public RealmBuilder configure(RealmBuilder realm) {
+        try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(REALM_JSON_NAME)) {
+            if (is == null) {
+                throw new RuntimeException(REALM_JSON_NAME + " not found in classpath");
+            }
+
+            ObjectMapper mapper = new ObjectMapper();
+            RealmRepresentation realmRep = mapper.readValue(is, RealmRepresentation.class);
+
+            return RealmBuilder.update(realmRep);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load " + REALM_JSON_NAME, e);
+        }
+    }
+}

--- a/tests/src/test/java-released/io/github/mabartos/AdaptiveRealmConfig.java
+++ b/tests/src/test/java-released/io/github/mabartos/AdaptiveRealmConfig.java
@@ -2,17 +2,21 @@ package io.github.mabartos;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.RealmConfig;
+import org.keycloak.testframework.realm.RealmConfigBuilder;
 
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Realm config for released Keycloak (26.5.x / 26.6.x) using {@link RealmConfigBuilder}
+ * in test-framework-core.
+ */
 public class AdaptiveRealmConfig implements RealmConfig {
     public static final String REALM_JSON_NAME = "test-adaptive-realm.json";
 
     @Override
-    public RealmBuilder configure(RealmBuilder realm) {
+    public RealmConfigBuilder configure(RealmConfigBuilder realm) {
         try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(REALM_JSON_NAME)) {
             if (is == null) {
                 throw new RuntimeException(REALM_JSON_NAME + " not found in classpath");
@@ -21,7 +25,7 @@ public class AdaptiveRealmConfig implements RealmConfig {
             ObjectMapper mapper = new ObjectMapper();
             RealmRepresentation realmRep = mapper.readValue(is, RealmRepresentation.class);
 
-            return RealmBuilder.update(realmRep);
+            return RealmConfigBuilder.update(realmRep);
         } catch (IOException e) {
             throw new RuntimeException("Failed to load " + REALM_JSON_NAME, e);
         }

--- a/tests/src/test/java/io/github/mabartos/AdaptiveRealmConfig.java
+++ b/tests/src/test/java/io/github/mabartos/AdaptiveRealmConfig.java
@@ -2,8 +2,8 @@ package io.github.mabartos;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.testframework.realm.RealmBuilder;
 import org.keycloak.testframework.realm.RealmConfig;
-import org.keycloak.testframework.realm.RealmConfigBuilder;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,7 +12,7 @@ public class AdaptiveRealmConfig implements RealmConfig {
     public static final String REALM_JSON_NAME = "test-adaptive-realm.json";
 
     @Override
-    public RealmConfigBuilder configure(RealmConfigBuilder realm) {
+    public RealmBuilder configure(RealmBuilder realm) {
         try (InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream(REALM_JSON_NAME)) {
             if (is == null) {
                 throw new RuntimeException(REALM_JSON_NAME + " not found in classpath");
@@ -21,7 +21,7 @@ public class AdaptiveRealmConfig implements RealmConfig {
             ObjectMapper mapper = new ObjectMapper();
             RealmRepresentation realmRep = mapper.readValue(is, RealmRepresentation.class);
 
-            return RealmConfigBuilder.update(realmRep);
+            return RealmBuilder.update(realmRep);
         } catch (IOException e) {
             throw new RuntimeException("Failed to load " + REALM_JSON_NAME, e);
         }


### PR DESCRIPTION
Hello,

The upstream Keycloak refactoring ([keycloak/keycloak#48315](https://github.com/keycloak/keycloak/pull/48315), merged 2026-04-23) extracted realm/client/user builders into a new keycloak-test-framework-builders artifact and renamed RealmConfigBuilder to RealmBuilder.

Before:
```txt
[INFO] --- compiler:3.14.0:testCompile (default-testCompile) @ keycloak-adaptive-authn-tests ---
[INFO] Recompiling the module because of changed source code.
[INFO] Compiling 5 source files with javac [debug parameters target 21] to target/test-classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/thomas/git/github/keycloak-adaptive-authn/tests/src/test/java/io/github/mabartos/AdaptiveRealmConfig.java:[15,41] cannot find symbol
  symbol:   class RealmConfigBuilder
  location: class io.github.mabartos.AdaptiveRealmConfig
[ERROR] /home/thomas/git/github/keycloak-adaptive-authn/tests/src/test/java/io/github/mabartos/AdaptiveRealmConfig.java:[15,12] cannot find symbol
  symbol:   class RealmConfigBuilder
  location: class io.github.mabartos.AdaptiveRealmConfig
[ERROR] /home/thomas/git/github/keycloak-adaptive-authn/tests/src/test/java/io/github/mabartos/AdaptiveRealmConfig.java:[24,20] cannot find symbol
  symbol:   variable RealmConfigBuilder
  location: class io.github.mabartos.AdaptiveRealmConfig
[INFO] 3 errors 
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```