### PR TITLE
fix(tests): assert gap range using default locale in RiskLevelValidationTest

### DIFF
--- a/core/src/test/java/io/github/mabartos/engine/algorithm/RiskLevelValidationTest.java
+++ b/core/src/test/java/io/github/mabartos/engine/algorithm/RiskLevelValidationTest.java
@@ -7,6 +7,7 @@ import io.github.mabartos.spi.level.SimpleRiskLevels;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -42,7 +43,8 @@ class RiskLevelValidationTest {
                 () -> RiskLevelValidator.validate(levels, "TestGapLevels"));
 
         assertTrue(exception.getMessage().contains("Gap detected"));
-        assertTrue(exception.getMessage().contains("0.33-0.35"));
+        String expectedGap = String.format(Locale.getDefault(), "%.2f-%.2f", 0.33, 0.35);
+        assertTrue(exception.getMessage().contains(expectedGap));
     }
 
     @Test


### PR DESCRIPTION
Hello,

RiskLevelValidationTest.testGapInLevels used to assert on the literal substring `0.33-0.35`. 
That only matches when String.format uses a dot as the decimal separator., but on my side (FR), RiskLevelValidator formats the gap as 0,33-0,35, so the test failed even though validation behaved correctly.

Before :
```log
[INFO] Running io.github.mabartos.engine.algorithm.RiskLevelValidationTest
[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.031 s <<< FAILURE! -- in io.github.mabartos.engine.algorithm.RiskLevelValidationTest
[ERROR] io.github.mabartos.engine.algorithm.RiskLevelValidationTest.testGapInLevels -- Time elapsed: 0.007 s <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <true> but was: <false>
        at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:158)
        at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:139)
        at org.junit.jupiter.api.AssertTrue.failNotTrue(AssertTrue.java:69)
        at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:41)
        at org.junit.jupiter.api.AssertTrue.assertTrue(AssertTrue.java:35)
        at org.junit.jupiter.api.Assertions.assertTrue(Assertions.java:195)
        at io.github.mabartos.engine.algorithm.RiskLevelValidationTest.testGapInLevels(RiskLevelValidationTest.java:45)
```

After :
```log
[INFO] Running io.github.mabartos.engine.algorithm.RiskLevelValidationTest
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.025 s -- in io.github.mabartos.engine.algorithm.RiskLevelValidationTest
```

Thank you @sachtouris for tips on #43 about this 👍️

Thomas