### PR TITLE
fix(evaluator): load LOGIN_ERROR for FailedLoginPatternRiskEvaluator

### DIFF
--- a/core/src/main/java/io/github/mabartos/context/user/LoginEventsContext.java
+++ b/core/src/main/java/io/github/mabartos/context/user/LoginEventsContext.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public abstract class LoginEventsContext extends AbstractUserContext<List<Event>> {
     public static final String LOGIN_EVENTS = "login-events-user-context";
-    public static final String LOGIN_FAILURES_EVENTS = "login-events-user-context";
+    public static final String LOGIN_FAILURES_EVENTS = "login-failures-events-user-context";
     public static final int MAX_EVENTS_COUNT = 60;
 
     public LoginEventsContext(KeycloakSession session) {

--- a/core/src/main/java/io/github/mabartos/evaluator/login/FailedLoginPatternRiskEvaluator.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/login/FailedLoginPatternRiskEvaluator.java
@@ -18,6 +18,7 @@ package io.github.mabartos.evaluator.login;
 
 import io.github.mabartos.context.UserContexts;
 import io.github.mabartos.context.user.KcLoginEventsContextFactory;
+import io.github.mabartos.context.user.KcLoginFailuresEventsContextFactory;
 import io.github.mabartos.context.user.LoginEventsContext;
 import io.github.mabartos.spi.evaluator.AbstractRiskEvaluator;
 import io.github.mabartos.spi.level.Risk;
@@ -49,10 +50,17 @@ import static io.github.mabartos.spi.level.Risk.Score.VERY_HIGH;
  */
 public class FailedLoginPatternRiskEvaluator extends AbstractRiskEvaluator {
     private final LoginEventsContext loginEventsContext;
+    private final LoginEventsContext loginFailuresEventsContext;
     private final List<EventType> RELEVANT_EVENTS = List.of(EventType.LOGIN, EventType.LOGIN_ERROR);
 
     public FailedLoginPatternRiskEvaluator(KeycloakSession session) {
         this.loginEventsContext = UserContexts.getContext(session, KcLoginEventsContextFactory.PROVIDER_ID);
+        this.loginFailuresEventsContext = UserContexts.getContext(session, KcLoginFailuresEventsContextFactory.PROVIDER_ID);
+    }
+
+    FailedLoginPatternRiskEvaluator(LoginEventsContext loginEventsContext, LoginEventsContext loginFailuresEventsContext) {
+        this.loginEventsContext = loginEventsContext;
+        this.loginFailuresEventsContext = loginFailuresEventsContext;
     }
 
     @Override
@@ -66,8 +74,8 @@ public class FailedLoginPatternRiskEvaluator extends AbstractRiskEvaluator {
             return Risk.invalid("User is null");
         }
 
-        var events = loginEventsContext.getData(realm, knownUser).orElse(null);
-        if (events == null || events.size() < 3) {
+        var events = loadLoginActivityEvents(realm, knownUser);
+        if (events.size() < 3) {
             return Risk.invalid("Not enough login events");
         }
 
@@ -115,6 +123,13 @@ public class FailedLoginPatternRiskEvaluator extends AbstractRiskEvaluator {
         }
 
         return risk;
+    }
+
+    private List<Event> loadLoginActivityEvents(RealmModel realm, UserModel knownUser) {
+        List<Event> events = new ArrayList<>();
+        loginEventsContext.getData(realm, knownUser).ifPresent(events::addAll);
+        loginFailuresEventsContext.getData(realm, knownUser).ifPresent(events::addAll);
+        return events;
     }
 
     private PatternAnalysis analyzePattern(List<Event> events, long currentTime, long timeWindowMs) {

--- a/core/src/test/java/io/github/mabartos/evaluator/login/FailedLoginPatternRiskEvaluatorTest.java
+++ b/core/src/test/java/io/github/mabartos/evaluator/login/FailedLoginPatternRiskEvaluatorTest.java
@@ -1,0 +1,139 @@
+package io.github.mabartos.evaluator.login;
+
+import io.github.mabartos.context.user.LoginEventsContext;
+import io.github.mabartos.spi.level.Risk;
+import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.keycloak.common.util.Time;
+import org.keycloak.events.Event;
+import org.keycloak.events.EventType;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+
+import java.lang.reflect.Proxy;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static io.github.mabartos.spi.level.Risk.Score.NONE;
+import static io.github.mabartos.spi.level.Risk.Score.VERY_HIGH;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class FailedLoginPatternRiskEvaluatorTest {
+
+    @Test
+    void detectsHighFailureRateWhenLoginErrorsArePresent() {
+        long now = Time.currentTimeMillis();
+        List<Event> failures = List.of(
+                loginError(now - Duration.ofMinutes(10).toMillis(), "10.0.0.1"),
+                loginError(now - Duration.ofMinutes(8).toMillis(), "10.0.0.1"),
+                loginError(now - Duration.ofMinutes(6).toMillis(), "10.0.0.1"),
+                loginError(now - Duration.ofMinutes(4).toMillis(), "10.0.0.1")
+        );
+        List<Event> successes = List.of(
+                login(now - Duration.ofMinutes(2).toMillis(), "10.0.0.1")
+        );
+
+        FailedLoginPatternRiskEvaluator evaluator = evaluator(successes, failures);
+        Risk risk = evaluator.evaluate(null, anyUser());
+
+        assertThat(risk.getScore(), is(VERY_HIGH));
+    }
+
+    @Test
+    void detectsFailuresEvenWhenManySuccessfulLoginsAreLoaded() {
+        long now = Time.currentTimeMillis();
+        List<Event> successes = new ArrayList<>();
+        for (int i = 0; i < 60; i++) {
+            successes.add(login(now - Duration.ofHours(2 + i).toMillis(), "10.0.0.1"));
+        }
+        successes.add(login(now - Duration.ofMinutes(2).toMillis(), "10.0.0.1"));
+        List<Event> failures = List.of(
+                loginError(now - Duration.ofMinutes(10).toMillis(), "10.0.0.1"),
+                loginError(now - Duration.ofMinutes(7).toMillis(), "10.0.0.1"),
+                loginError(now - Duration.ofMinutes(3).toMillis(), "10.0.0.1"),
+                loginError(now - Duration.ofMinutes(1).toMillis(), "10.0.0.1")
+        );
+
+        FailedLoginPatternRiskEvaluator evaluator = evaluator(successes, failures);
+        Risk risk = evaluator.evaluate(null, anyUser());
+
+        assertThat(risk.getScore(), is(VERY_HIGH));
+    }
+
+    @Test
+    void returnsNoneWhenOnlySuccessfulLoginsAreLoaded() {
+        long now = Time.currentTimeMillis();
+        List<Event> successes = List.of(
+                login(now - Duration.ofHours(2).toMillis(), "10.0.0.1"),
+                login(now - Duration.ofHours(1).toMillis(), "10.0.0.1"),
+                login(now - Duration.ofMinutes(30).toMillis(), "10.0.0.1")
+        );
+
+        FailedLoginPatternRiskEvaluator evaluator = evaluator(successes, List.of());
+        Risk risk = evaluator.evaluate(null, anyUser());
+
+        assertThat(risk.getScore(), is(NONE));
+    }
+
+    private static FailedLoginPatternRiskEvaluator evaluator(List<Event> successes, List<Event> failures) {
+        return new FailedLoginPatternRiskEvaluator(fixedEvents(successes), fixedEvents(failures));
+    }
+
+    private static LoginEventsContext fixedEvents(List<Event> events) {
+        return new LoginEventsContext(null) {
+            @Override
+            public EventType[] eventTypes() {
+                return new EventType[0];
+            }
+
+            @Override
+            public Optional<List<Event>> initData(@Nonnull RealmModel realm, @Nullable UserModel knownUser) {
+                return Optional.of(events);
+            }
+
+            @Override
+            public Optional<List<Event>> getData(@Nonnull RealmModel realm, @Nullable UserModel knownUser) {
+                return Optional.of(events);
+            }
+        };
+    }
+
+    private static UserModel anyUser() {
+        return (UserModel) Proxy.newProxyInstance(
+                UserModel.class.getClassLoader(),
+                new Class[]{UserModel.class},
+                (proxy, method, args) -> {
+                    Class<?> returnType = method.getReturnType();
+                    if (returnType == boolean.class) {
+                        return false;
+                    }
+                    if (returnType == int.class) {
+                        return 0;
+                    }
+                    if (returnType == long.class) {
+                        return 0L;
+                    }
+                    return null;
+                });
+    }
+
+    private static Event loginError(long time, String ip) {
+        return event(EventType.LOGIN_ERROR, time, ip);
+    }
+
+    private static Event login(long time, String ip) {
+        return event(EventType.LOGIN, time, ip);
+    }
+
+    private static Event event(EventType type, long time, String ip) {
+        Event event = new Event();
+        event.setType(type);
+        event.setTime(time);
+        event.setIpAddress(ip);
+        return event;
+    }
+}


### PR DESCRIPTION
Hello,

Load `LOGIN_ERROR` via `KcLoginFailuresEventsContext` and merge with `LOGIN` events in `FailedLoginPatternRiskEvaluator`.

FailedLoginPatternRiskEvaluator logs after :
```txt
keycloak-adaptive-authn  | DEBUG [io.github.mabartos.engine.AbstractRiskEngine] (executor-thread-4) Evaluator: FailedLoginPatternRiskEvaluator - Risk score: 'VERY_HIGH' (trust '1.00') - 5 ms - Reason: 4 failures out of 5 attempts in 1h
```

Closes #49

Thomas