### PR TITLE
ci: publish releases on semver tags with assets and GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,111 @@
-name: Publish Release to GitHub Packages
+# Builds release artifacts on version tags, publishes to GitHub Releases and GitHub Packages.
+
+name: Release
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'Release version to publish (e.g. 0.4.8)'
-        required: true
+  push:
+    tags:
+      - "[0-9]*.[0-9]*.[0-9]*"
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
-
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: maven
+
+      - name: Configure Maven for GitHub Packages
+        run: |
+          mkdir -p "${HOME}/.m2"
+          cat > "${HOME}/.m2/settings.xml" <<SETTINGS_EOF
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${{ github.actor }}</username>
+                <password>${{ secrets.GITHUB_TOKEN }}</password>
+              </server>
+            </servers>
+          </settings>
+          SETTINGS_EOF
 
       - name: Set release version
-        run: ./set-version.sh ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          ./set-version.sh "${VERSION}"
+          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
 
       - name: Deploy to GitHub Packages
-        run: ./mvnw deploy -DskipTests -Pbuild-distribution
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Publishing to https://maven.pkg.github.com/${GITHUB_REPOSITORY}"
+          ./mvnw -B -ntp -U clean deploy -pl core -am \
+            -Dmaven.test.skip=true \
+            -Pbuild-distribution \
+            -Dgithub.packages.repository="${GITHUB_REPOSITORY}"
+
+      - name: Prepare release assets
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          CORE_JAR="core/target/keycloak-adaptive-authn-${VERSION}.jar"
+          THEME_JAR="core/src/main/assembly/adaptive-authn-theme.jar"
+          REALM_JSON="core/src/main/assembly/adaptive-realm.json"
+          test -f "${CORE_JAR}"
+          test -f "${THEME_JAR}"
+          test -f "${REALM_JSON}"
+          cp "${CORE_JAR}" dist/keycloak-adaptive-authn.jar
+          cp "${THEME_JAR}" dist/
+          cp "${REALM_JSON}" dist/
+          (cd dist && for f in *.jar *.json; do sha256sum "${f}" > "${f}.sha256"; done)
+          ls -la dist/
+          (cd dist && cat *.sha256)
+
+      - name: Upload artifacts for release job
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release-assets
+          path: dist/
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release-assets
+          path: dist
+
+      - name: Verify release assets
+        run: |
+          set -euo pipefail
+          test -f dist/adaptive-authn-theme.jar
+          test -f dist/adaptive-realm.json
+          test -f dist/keycloak-adaptive-authn.jar
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ jobs:
           echo "Publishing to https://maven.pkg.github.com/${GITHUB_REPOSITORY}"
           ./mvnw -B -ntp -U clean deploy -pl core -am \
             -Dmaven.test.skip=true \
-            -Pbuild-distribution \
             -Dgithub.packages.repository="${GITHUB_REPOSITORY}"
 
       - name: Prepare release assets
@@ -68,9 +67,9 @@ jobs:
           test -f "${CORE_JAR}"
           test -f "${THEME_JAR}"
           test -f "${REALM_JSON}"
-          cp "${CORE_JAR}" dist/keycloak-adaptive-authn.jar
-          cp "${THEME_JAR}" dist/
-          cp "${REALM_JSON}" dist/
+          cp "${CORE_JAR}" dist/
+          cp "${THEME_JAR}" dist/adaptive-authn-theme-${VERSION}.jar
+          cp "${REALM_JSON}" dist/adaptive-realm-${VERSION}.json
           (cd dist && for f in *.jar *.json; do sha256sum "${f}" > "${f}.sha256"; done)
           ls -la dist/
           (cd dist && cat *.sha256)
@@ -97,9 +96,9 @@ jobs:
       - name: Verify release assets
         run: |
           set -euo pipefail
-          test -f dist/adaptive-authn-theme.jar
-          test -f dist/adaptive-realm.json
-          test -f dist/keycloak-adaptive-authn.jar
+          test -f dist/adaptive-authn-theme-${VERSION}.jar
+          test -f dist/adaptive-realm-${VERSION}.json
+          test -f dist/keycloak-adaptive-authn-${VERSION}.jar
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,6 +14,7 @@
     <name>Keycloak Adaptive Authentication Core</name>
 
     <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <repository>
             <id>github</id>
             <name>GitHub Packages</name>
-            <url>https://maven.pkg.github.com/mabartos/keycloak-adaptive-authn</url>
+            <url>https://maven.pkg.github.com/${github.packages.repository}</url>
         </repository>
     </distributionManagement>
 
@@ -59,6 +59,10 @@
     </repositories>
 
     <properties>
+        <!-- Override in CI: -Dgithub.packages.repository=${{ github.repository }} -->
+        <github.packages.repository>mabartos/keycloak-adaptive-authn</github.packages.repository>
+        <!-- Parent is not published; only core is deployed from CI -->
+        <maven.deploy.skip>true</maven.deploy.skip>
         <keycloak.version>999.0.0-SNAPSHOT</keycloak.version>
         <quarkus.version>3.33.1</quarkus.version>
 


### PR DESCRIPTION
Closes #56

Validated on my fork : https://github.com/thomasdelorge/keycloak-adaptive-authn/actions
Example : https://github.com/thomasdelorge/keycloak-adaptive-authn/releases/tag/1.0.10

<img width="1216" height="705" alt="image" src="https://github.com/user-attachments/assets/aae43799-cb30-4cc3-a112-1eabb3890176" />

@mabartos : Feel free to enable immutable releases on the repo (assets locked; description still editable).

Thomas
