### PR TITLE
fix(engine): tolerate missing authentication session in stored risk provider

### DIFF
--- a/core/src/main/java/io/github/mabartos/engine/AuthnSessionStoredRiskProvider.java
+++ b/core/src/main/java/io/github/mabartos/engine/AuthnSessionStoredRiskProvider.java
@@ -85,13 +85,14 @@ public class AuthnSessionStoredRiskProvider implements StoredRiskProvider {
 
     @Override
     public void storeAdditionalData(String key, String value) {
-        var authnSession = getAuthnSession().orElseThrow();
-        authnSession.setAuthNote(key, value);
+        getAuthnSession().ifPresentOrElse(
+                authnSession -> authnSession.setAuthNote(key, value),
+                () -> logger.debugf("Skipping store of '%s': no authentication session available", key));
     }
 
     @Override
     public Optional<String> getAdditionalData(String key) {
-        return Optional.ofNullable(getAuthnSession().orElseThrow(() -> new IllegalStateException("Authentication session is null")).getAuthNote(key));
+        return getAuthnSession().map(authnSession -> authnSession.getAuthNote(key));
     }
 
     protected Optional<AuthenticationSessionModel> getAuthnSession() {


### PR DESCRIPTION
Hello,

Make `AuthnSessionStoredRiskProvider` tolerate a missing `AuthenticationSession`
on both read and write:

## Why

Continuous risk evaluation runs on a background timer
(`ScheduledContinuousRiskEvaluation`), outside any login flow, so there is no
authentication session.
The provider assumed one always exists (`orElseThrow`) so the task crashed on every run with :

```
ERROR [...ScheduledTaskRunner] (Timer-0) Failed to run scheduled task ScheduledContinuousRiskEvaluation: java.lang.IllegalStateException: Authentication session is null
    at io.github.mabartos.engine.AbstractRiskEngine.evaluateRisk(AbstractRiskEngine.java:73)
    at io.github.mabartos.engine.AuthnSessionStoredRiskProvider.getAdditionalData(AuthnSessionStoredRiskProvider.java:94)
    at java.base/java.util.Optional.orElseThrow(Optional.java:403)
```

Closes #55