### PR TITLE
Federated LDAP users with READ_ONLY mode are not supported

### DIFF
--- a/core/src/main/java/io/github/mabartos/engine/AbstractRiskEngine.java
+++ b/core/src/main/java/io/github/mabartos/engine/AbstractRiskEngine.java
@@ -70,6 +70,9 @@ public abstract class AbstractRiskEngine implements RiskEngine {
             return ResultRisk.invalid("Cannot execute risk score evaluation, because the user needs to be known");
         }
 
+        // Route attribute reads/writes to federated storage for non-imported users (e.g. READ_ONLY LDAP)
+        knownUser = FederatedStorageUserModelDelegate.wrapIfNeeded(knownUser, session, realm);
+
         final var storedRisk = storedRiskProvider.getStoredRisk(phase);
         if (storedRisk.isValid()) {
             logger.debugf("Risk for phase '%s' is already evaluated ('%s'). Skipping it...", phase.name(), storedRisk.getScore());

--- a/core/src/main/java/io/github/mabartos/engine/FederatedStorageUserModelDelegate.java
+++ b/core/src/main/java/io/github/mabartos/engine/FederatedStorageUserModelDelegate.java
@@ -1,0 +1,109 @@
+package io.github.mabartos.engine;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.utils.UserModelDelegate;
+import org.keycloak.storage.StorageId;
+import org.keycloak.storage.UserStorageUtil;
+import org.keycloak.storage.federated.UserFederatedStorageProvider;
+
+import static org.keycloak.common.util.CollectionUtil.isNotEmpty;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Transparently routes attribute operations to Keycloak's federated storage
+ * for non-local (non-imported) users, e.g. LDAP users with import disabled.
+ * <p>
+ * This avoids {@link org.keycloak.storage.ReadOnlyException} when the extension
+ * needs to persist adaptive authentication data alongside read-only federated users.
+ * Federated storage writes to Keycloak's own database, not to the external source.
+ */
+public class FederatedStorageUserModelDelegate extends UserModelDelegate {
+
+    private final KeycloakSession session;
+    private final RealmModel realm;
+    private final boolean localStorage;
+
+    private FederatedStorageUserModelDelegate(UserModel delegate, KeycloakSession session, RealmModel realm) {
+        super(delegate);
+        this.session = session;
+        this.realm = realm;
+        this.localStorage = StorageId.isLocalStorage(delegate.getId());
+    }
+
+    /**
+     * Wraps the user model to route attribute operations to federated storage
+     * if the user is non-local (e.g. non-imported LDAP with READ_ONLY mode).
+     * Returns the original user model unchanged for local/imported users.
+     */
+    public static UserModel wrapIfNeeded(UserModel user, KeycloakSession session, RealmModel realm) {
+        if (user == null || StorageId.isLocalStorage(user.getId())) {
+            return user;
+        }
+        return new FederatedStorageUserModelDelegate(user, session, realm);
+    }
+
+    @Override
+    public void setSingleAttribute(String name, String value) {
+        if (!localStorage) {
+            federatedStorage().setSingleAttribute(realm, getId(), name, value);
+            return;
+        }
+        super.setSingleAttribute(name, value);
+    }
+
+    @Override
+    public void setAttribute(String name, List<String> values) {
+        if (!localStorage) {
+            federatedStorage().setAttribute(realm, getId(), name, values);
+            return;
+        }
+        super.setAttribute(name, values);
+    }
+
+    @Override
+    public void removeAttribute(String name) {
+        if (!localStorage) {
+            federatedStorage().removeAttribute(realm, getId(), name);
+            return;
+        }
+        super.removeAttribute(name);
+    }
+
+    @Override
+    public String getFirstAttribute(String name) {
+        if (!localStorage) {
+            List<String> values = federatedStorage().getAttributes(realm, getId()).get(name);
+            return isNotEmpty(values) ? values.getFirst() : null;
+        }
+        return super.getFirstAttribute(name);
+    }
+
+    @Override
+    public Stream<String> getAttributeStream(String name) {
+        if (!localStorage) {
+            List<String> values = federatedStorage().getAttributes(realm, getId()).get(name);
+            return isNotEmpty(values) ? values.stream() : Stream.empty();
+        }
+        return super.getAttributeStream(name);
+    }
+
+    @Override
+    public Map<String, List<String>> getAttributes() {
+        if (!localStorage) {
+            Map<String, List<String>> attributes = new HashMap<>(super.getAttributes());
+            attributes.putAll(federatedStorage().getAttributes(realm, getId()));
+            return attributes;
+        }
+        return super.getAttributes();
+    }
+
+    private UserFederatedStorageProvider federatedStorage() {
+        return UserStorageUtil.userFederatedStorage(session);
+    }
+}

--- a/core/src/main/java/io/github/mabartos/engine/LoginEventsEventListener.java
+++ b/core/src/main/java/io/github/mabartos/engine/LoginEventsEventListener.java
@@ -10,6 +10,7 @@ import org.keycloak.events.EventListenerProvider;
 import org.keycloak.events.admin.AdminEvent;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
 import org.keycloak.timer.ScheduledTask;
 import org.keycloak.timer.TimerProvider;
 import org.keycloak.utils.StringUtil;
@@ -48,22 +49,23 @@ public class LoginEventsEventListener implements EventListenerProvider {
             return;
         }
 
-        switch (event.getType()) {
-            case LOGIN -> handleLogin(event, realm);
-            case LOGOUT -> handleLogout(event, realm);
-        }
-    }
-
-    protected void handleLogin(Event event, RealmModel realm) {
         var userId = event.getUserId();
         if (StringUtil.isBlank(userId)) return;
 
-        var user = session.users().getUserById(realm, userId);
+        // Route attribute reads/writes to federated storage for non-imported users (e.g. READ_ONLY LDAP)
+        var user = FederatedStorageUserModelDelegate.wrapIfNeeded(session.users().getUserById(realm, userId), session, realm);
         if (user == null) {
-            log.warnf("User with user ID '%s' does not exist, so no timer cannot be created.", userId);
+            log.warnf("User with user ID '%s' does not exist.", userId);
             return;
         }
 
+        switch (event.getType()) {
+            case LOGIN -> handleLogin(user, realm);
+            case LOGOUT -> handleLogout(user, realm);
+        }
+    }
+
+    protected void handleLogin(UserModel user, RealmModel realm) {
         session.getAllProviders(UserContext.class)
                 .stream()
                 .filter(context -> context instanceof OnSuccessfulLoginCallback)
@@ -71,11 +73,11 @@ public class LoginEventsEventListener implements EventListenerProvider {
 
         var timerScheduled = user.getFirstAttribute(USER_ATTRIBUTE_CONTINUOUS_EVALUATIONS_TIMER_SET);
         if (!Boolean.parseBoolean(timerScheduled)) {
-            timerProvider.scheduleTask(new ScheduledContinuousRiskEvaluation(realm.getId(), userId),
+            timerProvider.scheduleTask(new ScheduledContinuousRiskEvaluation(realm.getId(), user.getId()),
                     Duration.ofMinutes(DEFAULT_CONTINUOUS_RISK_EVALUATION_PERIOD_MINUTES).toMillis(),
-                    getUserTimerName(userId));
+                    getUserTimerName(user.getId()));
             user.setAttribute(USER_ATTRIBUTE_CONTINUOUS_EVALUATIONS_TIMER_SET, List.of("true"));
-            log.debugf("Scheduled task for continuous risk evaluation was set. (User ID: '%s', period in minutes: '%d'", userId, DEFAULT_CONTINUOUS_RISK_EVALUATION_PERIOD_MINUTES);
+            log.debugf("Scheduled task for continuous risk evaluation was set. (User ID: '%s', period in minutes: '%d'", user.getId(), DEFAULT_CONTINUOUS_RISK_EVALUATION_PERIOD_MINUTES);
         }
     }
 
@@ -93,21 +95,15 @@ public class LoginEventsEventListener implements EventListenerProvider {
             var riskEngine = session.getProvider(RiskEngine.class);
             var realm = session.realms().getRealm(realmId);
             session.getContext().setRealm(realm);
-            var user = session.users().getUserById(realm, userId);
+
+            // Route attribute reads/writes to federated storage for non-imported users (e.g. READ_ONLY LDAP)
+            var user = FederatedStorageUserModelDelegate.wrapIfNeeded(session.users().getUserById(realm, userId), session, realm);
             riskEngine.evaluateRisk(RiskEvaluator.EvaluationPhase.CONTINUOUS, realm, user);
         }
     }
 
-    protected void handleLogout(Event event, RealmModel realm) {
-        var userId = event.getUserId();
-        if (StringUtil.isBlank(userId)) return;
-
-        var user = session.users().getUserById(realm, userId);
-        if (user == null) {
-            log.warnf("User with user ID '%s' does not exist, so no timer cannot be cancelled.", userId);
-            return;
-        }
-        timerProvider.cancelTask(getUserTimerName(userId));
+    protected void handleLogout(UserModel user, RealmModel realm) {
+        timerProvider.cancelTask(getUserTimerName(user.getId()));
         user.removeAttribute(USER_ATTRIBUTE_CONTINUOUS_EVALUATIONS_TIMER_SET);
     }
 


### PR DESCRIPTION
- Closes #48
- @sachtouris Would be better to provide the federated storage user delegate than handling these attributes at their calls -> Would be nice if you could review this PR and try it out with your environment, thanks! :rocket: 