### PR TITLE
fix(ui): show initial evaluator trust and enabled in risk policies tab

### DIFF
--- a/core/src/main/java/io/github/mabartos/evaluator/EvaluatorUtils.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/EvaluatorUtils.java
@@ -68,6 +68,7 @@ public class EvaluatorUtils {
     public static boolean isEvaluatorEnabled(RealmModel realm, Class<? extends RiskEvaluator> evaluator, boolean defaultValue) {
         return Optional.ofNullable(realm)
                 .map(f -> f.getAttribute(RiskEvaluatorFactory.isEnabledConfig(evaluator)))
+                .filter(StringUtils::isNotBlank)
                 .map(Boolean::parseBoolean)
                 .orElse(defaultValue);
     }

--- a/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
+++ b/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
@@ -49,6 +49,8 @@ import static io.github.mabartos.spi.engine.RiskEngineFactory.DEFAULT_EVALUATOR_
 import static io.github.mabartos.spi.engine.RiskEngineFactory.DEFAULT_EVALUATOR_TIMEOUT;
 import static io.github.mabartos.spi.engine.RiskEngineFactory.EVALUATOR_RETRIES_CONFIG;
 import static io.github.mabartos.spi.engine.RiskEngineFactory.EVALUATOR_TIMEOUT_CONFIG;
+import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.ENABLED_CONFIG;
+import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.TRUST_CONFIG;
 import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.getTrustConfig;
 import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.isEnabledConfig;
 
@@ -57,6 +59,8 @@ import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.isEnabledCon
  */
 public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFactory<ComponentModel> {
     private static final Logger logger = Logger.getLogger(RiskBasedPoliciesUiTab.class);
+
+    private static final String UI_TAB_PROVIDER_TYPE = "org.keycloak.services.ui.extend.UiTabProvider";
 
     private static final String TRUST_FIELD_HELP =
             "Weight from 0 to 1 (e.g. 0.75). 1 = full influence on the combined risk score.";
@@ -153,23 +157,7 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
                     }
                 }));
 
-        riskEvaluatorFactories.forEach(f -> {
-            var enabledKey = isEnabledConfig(f.evaluatorClass());
-            if (!Objects.equals(oldModel.get(enabledKey), newModel.get(enabledKey)) && newModel.contains(enabledKey)) {
-                var value = newModel.get(enabledKey);
-                var enabled = value == null || Boolean.parseBoolean(value);
-                logger.debugf("onUpdate storing evaluator enabled '%s' = '%s'", enabledKey, enabled);
-                EvaluatorUtils.setEvaluatorEnabled(realm, f.evaluatorClass(), enabled);
-            }
-
-            var trustKey = getTrustConfig(f.evaluatorClass());
-            var oldTrust = oldModel.get(trustKey);
-            var newTrust = newModel.get(trustKey);
-            if (!Objects.equals(oldTrust, newTrust) && newModel.contains(trustKey) && StringUtil.isNotBlank(newTrust)) {
-                logger.debugf("onUpdate storing evaluator trust '%s' = '%s' (was '%s')", trustKey, newTrust, oldTrust);
-                EvaluatorUtils.storeEvaluatorTrust(realm, f.evaluatorClass(), Double.parseDouble(newTrust));
-            }
-        });
+        riskEvaluatorFactories.forEach(f -> persistEvaluatorSettings(newModel, realm, f, "onUpdate"));
     }
 
     private void persistEvaluatorSettings(ComponentModel model, RealmModel realm, RiskEvaluatorFactory evalFactory, String context) {
@@ -193,6 +181,10 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
     public void validateConfiguration(KeycloakSession session, RealmModel realm, ComponentModel model) throws ComponentValidationException {
         logger.tracef("validateConfiguration execution");
 
+        validateEvaluatorTrustValues(model);
+
+        var persisted = resolvePersistedTabComponent(realm, model);
+        hydrateModelFromRealmAttributes(realm, model, persisted);
         populateMissingDefaults(model);
 
         validateInteger(model.get(EVALUATOR_TIMEOUT_CONFIG), "Timeout");
@@ -200,7 +192,9 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
 
         validateFallbackLevel(model.get(SIMPLE_FALLBACK_LEVEL_CONFIG), SimpleRiskLevels.getSimpleLevelNames(), "Simple fallback risk level");
         validateFallbackLevel(model.get(ADVANCED_FALLBACK_LEVEL_CONFIG), AdvancedRiskLevels.getAdvancedLevelNames(), "Advanced fallback risk level");
+    }
 
+    private void validateEvaluatorTrustValues(ComponentModel model) {
         riskEvaluatorFactories.forEach(f -> {
             var value = model.get(getTrustConfig(f.evaluatorClass()));
             if (StringUtil.isBlank(value)) {
@@ -224,6 +218,86 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
                 model.getConfig().putSingle(prop.getName(), prop.getDefaultValue().toString());
             }
         });
+    }
+
+    /**
+     * Aligns the component model with realm attributes before the form is rendered.
+     * Evaluator enabled/trust keys use non-blank realm attributes as source of truth; when absent,
+     * stale component config is cleared so schema defaults apply, matching runtime fallbacks.
+     * Other properties keep the component value when set, otherwise fall back to realm attributes.
+     */
+    void hydrateModelFromRealmAttributes(RealmModel realm, ComponentModel model, ComponentModel persisted) {
+        if (realm == null) {
+            return;
+        }
+        getConfigProperties().forEach(prop -> {
+            var key = prop.getName();
+            var realmValue = realm.getAttribute(key);
+            if (isRealmSourcedEvaluatorSetting(key)) {
+                if (StringUtil.isNotBlank(realmValue)) {
+                    logger.tracef("Hydrating '%s' from realm attribute (evaluator setting)", key);
+                    model.getConfig().putSingle(key, realmValue);
+                } else if (isUnchangedStaleComponentValue(persisted, key, model.get(key))) {
+                    logger.tracef("Clearing stale component config for '%s' (no realm attribute)", key);
+                    model.getConfig().remove(key);
+                } else if (isAdminSubmittedEvaluatorChange(persisted, key, model.get(key))) {
+                    logger.tracef("Keeping submitted evaluator setting '%s' = '%s' (no realm attribute yet)", key, model.get(key));
+                } else if (model.contains(key)) {
+                    logger.tracef("Clearing evaluator setting '%s' (no realm attribute, not an admin change)", key);
+                    model.getConfig().remove(key);
+                }
+                return;
+            }
+            if (StringUtil.isNotBlank(model.get(key))) {
+                return;
+            }
+            if (StringUtil.isNotBlank(realmValue)) {
+                logger.tracef("Hydrating '%s' from realm attribute", key);
+                model.getConfig().putSingle(key, realmValue);
+            }
+        });
+    }
+
+    private static boolean isRealmSourcedEvaluatorSetting(String key) {
+        return key.startsWith(ENABLED_CONFIG) || key.startsWith(TRUST_CONFIG);
+    }
+
+    private ComponentModel resolvePersistedTabComponent(RealmModel realm, ComponentModel model) {
+        if (realm == null) {
+            return null;
+        }
+        if (StringUtil.isNotBlank(model.getId())) {
+            var byId = realm.getComponent(model.getId());
+            if (byId != null) {
+                return byId;
+            }
+        }
+        return realm.getComponentsStream(realm.getId(), UI_TAB_PROVIDER_TYPE)
+                .filter(component -> getId().equals(component.getProviderId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Stale component config matches persisted storage and was not changed in the submitted model.
+     */
+    private static boolean isUnchangedStaleComponentValue(ComponentModel persisted, String key, String submitted) {
+        return persisted != null
+                && persisted.getConfig().containsKey(key)
+                && Objects.equals(submitted, persisted.get(key));
+    }
+
+    /**
+     * Admin changed a value or set one that is not stored on the tab component yet (first save).
+     */
+    private static boolean isAdminSubmittedEvaluatorChange(ComponentModel persisted, String key, String submitted) {
+        if (StringUtil.isBlank(submitted) || persisted == null) {
+            return false;
+        }
+        if (!persisted.getConfig().containsKey(key)) {
+            return true;
+        }
+        return !Objects.equals(submitted, persisted.get(key));
     }
 
     protected void validateInteger(String value, String attributeDisplayName) {
@@ -341,6 +415,7 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
                 .label(RiskEvaluatorUi.trustLabel(factory))
                 .helpText(RiskEvaluatorUi.trustTooltip() + " " + TRUST_FIELD_HELP)
                 .type(ProviderConfigProperty.STRING_TYPE)
+                .defaultValue(Trust.FULL)
                 .add()
                 .build()
                 .getFirst());

--- a/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
+++ b/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.github.mabartos.spi.engine.RiskEngineFactory.EVALUATOR_TIMEOUT_CONFIG;
 import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.getTrustConfig;
 import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.isEnabledConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,7 +34,7 @@ class RiskBasedPoliciesUiTabPersistenceTest {
     @BeforeEach
     void setUp() throws Exception {
         realmAttributes.clear();
-        realm = realmBackedBy(realmAttributes);
+        realm = realmBackedBy(realmAttributes, Map.of(), List.of());
         tab = new RiskBasedPoliciesUiTab();
         browserFactory = new BrowserRiskEvaluatorFactory();
         injectFactories(tab, List.of(browserFactory));
@@ -102,9 +103,218 @@ class RiskBasedPoliciesUiTabPersistenceTest {
         tab.validateConfiguration(null, realm, model);
     }
 
+    @Test
+    void validateConfiguration_hydratesTrustFromRealmAttributeWhenModelEmpty() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        realmAttributes.put(trustKey, "0.5");
+
+        var model = new ComponentModel();
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("0.5", model.get(trustKey));
+    }
+
+    @Test
+    void validateConfiguration_hydratesEngineSettingFromRealmAttributeWhenModelEmpty() {
+        realmAttributes.put(EVALUATOR_TIMEOUT_CONFIG, "5000");
+
+        var model = new ComponentModel();
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("5000", model.get(EVALUATOR_TIMEOUT_CONFIG));
+    }
+
+    @Test
+    void validateConfiguration_prefersRealmTrustOverExistingModelValue() {
+        realmAttributes.put(getTrustConfig(BrowserRiskEvaluator.class), "0.5");
+
+        var model = componentModel(Map.of(getTrustConfig(BrowserRiskEvaluator.class), "0.75"));
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("0.5", model.get(getTrustConfig(BrowserRiskEvaluator.class)));
+    }
+
+    @Test
+    void validateConfiguration_appliesTrustDefaultWhenModelAndRealmEmpty() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        var model = new ComponentModel();
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("1.0", model.get(trustKey));
+    }
+
+    @Test
+    void validateConfiguration_hydratesEnabledFalseFromRealmWhenModelEmpty() {
+        var enabledKey = isEnabledConfig(BrowserRiskEvaluator.class);
+        realmAttributes.put(enabledKey, "false");
+
+        var model = new ComponentModel();
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("false", model.get(enabledKey));
+    }
+
+    @Test
+    void validateConfiguration_overridesStaleModelEnabledWithRealmAttribute() {
+        var enabledKey = isEnabledConfig(BrowserRiskEvaluator.class);
+        realmAttributes.put(enabledKey, "false");
+
+        var model = componentModel(Map.of(enabledKey, "true"));
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("false", model.get(enabledKey));
+    }
+
+    @Test
+    void validateConfiguration_appliesEnabledDefaultWhenModelAndRealmEmpty() {
+        var enabledKey = isEnabledConfig(BrowserRiskEvaluator.class);
+        var model = new ComponentModel();
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("true", model.get(enabledKey));
+    }
+
+    @Test
+    void validateConfiguration_appliesEnabledDefaultWhenRealmAttributeBlank() {
+        var enabledKey = isEnabledConfig(BrowserRiskEvaluator.class);
+        realmAttributes.put(enabledKey, "");
+
+        var model = new ComponentModel();
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("true", model.get(enabledKey));
+    }
+
+    @Test
+    void validateConfiguration_appliesTrustDefaultWhenRealmAttributeBlank() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        realmAttributes.put(trustKey, "");
+
+        var model = new ComponentModel();
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("1.0", model.get(trustKey));
+    }
+
+    @Test
+    void validateConfiguration_discardsStaleModelTrustWhenNoRealmAttribute() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        var persisted = tabComponent(Map.of(trustKey, "0.75"));
+        persisted.setId("risk-tab");
+        var model = componentModel(Map.of(trustKey, "0.75"));
+        model.setId("risk-tab");
+        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("1.0", model.get(trustKey));
+    }
+
+    @Test
+    void validateConfiguration_discardsStaleModelEnabledWhenNoRealmAttribute() {
+        var enabledKey = isEnabledConfig(BrowserRiskEvaluator.class);
+        var persisted = tabComponent(Map.of(enabledKey, "false"));
+        persisted.setId("risk-tab");
+        var model = componentModel(Map.of(enabledKey, "false"));
+        model.setId("risk-tab");
+        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("true", model.get(enabledKey));
+    }
+
+    @Test
+    void validateConfiguration_clearsStaleTrustWhenPersistedComponentUnknown() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        var model = componentModel(Map.of(trustKey, "0.2"));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("1.0", model.get(trustKey));
+    }
+
+    @Test
+    void validateConfiguration_clearsStaleTrustWhenModelHasNoComponentId() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        var persisted = tabComponent(Map.of(trustKey, "0.2"));
+        var model = componentModel(Map.of(trustKey, "0.2"));
+        realm = realmBackedBy(realmAttributes, Map.of(), List.of(persisted));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("1.0", model.get(trustKey));
+    }
+
+    @Test
+    void validateConfiguration_preservesFirstSaveTrustWhenModelHasNoComponentId() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        var persisted = tabComponent(Map.of(RiskBasedPoliciesUiTab.RISK_BASED_AUTHN_ENABLED_CONFIG, "true"));
+        var model = componentModel(Map.of(trustKey, "0.5"));
+        realm = realmBackedBy(realmAttributes, Map.of(), List.of(persisted));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("0.5", model.get(trustKey));
+    }
+
+    @Test
+    void validateConfiguration_preservesSubmittedTrustOnVirginRealmFirstSave() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        var enabledKey = isEnabledConfig(BrowserRiskEvaluator.class);
+        var persisted = tabComponent(Map.of(
+                RiskBasedPoliciesUiTab.RISK_BASED_AUTHN_ENABLED_CONFIG, "true"));
+        persisted.setId("risk-tab");
+        var model = componentModel(Map.of(
+                trustKey, "0.5",
+                enabledKey, "true",
+                RiskBasedPoliciesUiTab.RISK_BASED_AUTHN_ENABLED_CONFIG, "true"));
+        model.setId("risk-tab");
+        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("0.5", model.get(trustKey));
+
+        tab.onUpdate(null, realm, persisted, model);
+
+        assertEquals("0.5", realmAttributes.get(trustKey));
+    }
+
+    @Test
+    void onUpdate_persistsTrustToRealmEvenWhenUnchanged() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        var model = componentModel(Map.of(trustKey, "0.5"));
+
+        tab.onUpdate(null, realm, model, model);
+
+        assertEquals("0.5", realmAttributes.get(trustKey));
+    }
+
+    @Test
+    void onUpdate_persistsEvaluatorSettingsFromFormAfterStaleComponentCleared() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        var enabledKey = isEnabledConfig(BrowserRiskEvaluator.class);
+        var oldModel = componentModel(Map.of(trustKey, "0.75", enabledKey, "false"));
+        var newModel = componentModel(Map.of(trustKey, "1.0", enabledKey, "true"));
+
+        tab.onUpdate(null, realm, oldModel, newModel);
+
+        assertEquals("1.0", realmAttributes.get(trustKey));
+        assertEquals("true", realmAttributes.get(enabledKey));
+    }
+
     private static ComponentModel componentModel(Map<String, String> entries) {
         var model = new ComponentModel();
         entries.forEach((key, value) -> model.getConfig().putSingle(key, value));
+        return model;
+    }
+
+    private static ComponentModel tabComponent(Map<String, String> entries) {
+        var model = componentModel(entries);
+        model.setProviderId("Risk-based policies");
         return model;
     }
 
@@ -120,7 +330,10 @@ class RiskBasedPoliciesUiTabPersistenceTest {
         field.set(target, value);
     }
 
-    private static RealmModel realmBackedBy(Map<String, String> attributes) {
+    private static RealmModel realmBackedBy(
+            Map<String, String> attributes,
+            Map<String, ComponentModel> componentsById,
+            List<ComponentModel> uiTabComponents) {
         return (RealmModel) java.lang.reflect.Proxy.newProxyInstance(
                 RealmModel.class.getClassLoader(),
                 new Class<?>[] {RealmModel.class},
@@ -130,6 +343,19 @@ class RiskBasedPoliciesUiTabPersistenceTest {
                         yield null;
                     }
                     case "getAttribute" -> attributes.get((String) args[0]);
+                    case "getComponent" -> componentsById.get((String) args[0]);
+                    case "getComponentsStream" -> {
+                        if (args != null && args.length == 2
+                                && "test-realm".equals(args[0])
+                                && "org.keycloak.services.ui.extend.UiTabProvider".equals(args[1])) {
+                            yield uiTabComponents.stream();
+                        }
+                        if (args != null && args.length == 1
+                                && "org.keycloak.services.ui.extend.UiTabProvider".equals(args[0])) {
+                            yield uiTabComponents.stream();
+                        }
+                        yield java.util.stream.Stream.<ComponentModel>empty();
+                    }
                     case "getId" -> "test-realm";
                     default -> defaultValue(method.getReturnType());
                 });


### PR DESCRIPTION
Hello @mabartos ,

On Risk-based policies, trust and enabled fields can show up empty or wrong when you open the tab.

The engine reads realm attributes (`adaptive-evaluator-trust-*`, `adaptive-evaluator-enabled-*`). The admin UI keeps its own copy in the component model (Tab UI SPI). After a realm import, those two can diverge. The form was showing the component side, not what the engine actually uses.

Same idea as `ClientRiskSettingsUiTab`: reload the real values in `validateConfiguration` before render.

## Proposal

All in `RiskBasedPoliciesUiTab`:

- Trust fields get a default (`1.0`), like enabled already had `true`.
- On tab open / validate, copy non-blank realm attributes into the form.
- Stale component (no realm attribute): drop it and apply schema defaults.
- Admin change (value differs from persisted component, or key not on component yet): keep through `validateConfiguration` → `onUpdate` (first custom save on a virgin row).
- On save, flush all evaluator enabled/trust to realm attributes, edited or not (re-sync after import).
- `EvaluatorUtils.isEvaluatorEnabled`: blank realm attribute `""` now treated as absent (same as trust), default `true`.

## Test

```bash
mvn test -pl core -Dtest=RiskBasedPoliciesUiTabPersistenceTest
```

23 unit tests (hydration, stale clear at import/open, first save, `getComponentsStream(realm.getId(), …)` lookup).

### Manual tests (`declarative-ui`, realm `adaptive`)

The matrix below is for manual PR review only. I did not ship it in `adaptive-realm.json`: it deliberately sets conflicting realm vs outdated component values, which is useful to exercise this fix but would clutter the default demo realm without helping adopters. Patch your local `adaptive-realm.json` before reimport if you want to replay the table.

<details>
<summary>📄 QA fixture JSON (realm attributes + TabUi component config)</summary>

```jsonc
// realm.attributes - engine source of truth (- = omit key or use "")
{
  // Known location → tab true / 0.75
  "adaptive-evaluator-enabled-KnownLocationRiskEvaluator": "true",
  "adaptive-evaluator-trust-KnownLocationRiskEvaluator": "0.75",

  // Browser → tab false / 0.5 (beats component true / 0.99)
  "adaptive-evaluator-enabled-BrowserRiskEvaluator": "false",
  "adaptive-evaluator-trust-BrowserRiskEvaluator": "0.5",

  // Login failures → tab false / 0.25 (beats component true / 0.9)
  "adaptive-evaluator-enabled-LoginFailuresRiskEvaluator": "false",
  "adaptive-evaluator-trust-LoginFailuresRiskEvaluator": "0.25",

  // Unusual login time → tab true / 0.8 (trust only in realm; component 0.1 ignored)
  "adaptive-evaluator-trust-TimePatternRiskEvaluator": "0.8",

  // AI account takeover → tab false / 0.4
  "adaptive-evaluator-enabled-AiAccountTakeoverEvaluator": "false",
  "adaptive-evaluator-trust-AiAccountTakeoverEvaluator": "0.4",

  // Recaptcha → tab true / 1.0 (blank attrs; outdated component 0.3 dropped)
  "adaptive-evaluator-enabled-RecaptchaRiskEvaluator": "",
  "adaptive-evaluator-trust-RecaptchaRiskEvaluator": "",

  // Operating system → tab true / 1.0 (blank enabled; outdated component ignored)
  "adaptive-evaluator-enabled-OperatingSystemRiskEvaluator": ""

  // User actions, Init location: no keys (defaults; Init = first-save playground)
}

// components → org.keycloak.services.ui.extend.UiTabProvider → "Risk-based policies" → config
{
  "adaptive-evaluator-enabled-KnownLocationRiskEvaluator": ["true"],   // no trust key

  "adaptive-evaluator-enabled-BrowserRiskEvaluator": ["true"],
  "adaptive-evaluator-trust-BrowserRiskEvaluator": ["0.99"],

  "adaptive-evaluator-enabled-LoginFailuresRiskEvaluator": ["true"],
  "adaptive-evaluator-trust-LoginFailuresRiskEvaluator": ["0.9"],

  "adaptive-evaluator-enabled-TimePatternRiskEvaluator": ["true"],
  "adaptive-evaluator-trust-TimePatternRiskEvaluator": ["0.1"],

  "adaptive-evaluator-enabled-AiAccountTakeoverEvaluator": ["true"],   // no trust key

  "adaptive-evaluator-enabled-RecaptchaRiskEvaluator": ["true"],
  "adaptive-evaluator-trust-RecaptchaRiskEvaluator": ["0.3"],

  "adaptive-evaluator-enabled-UserActionsRiskEvaluator": ["false"],
  "adaptive-evaluator-trust-UserActionsRiskEvaluator": ["0.2"],

  "adaptive-evaluator-enabled-OperatingSystemRiskEvaluator": ["true"]  // no trust key

  // InitLocationRiskEvaluator: absent (virgin row)
}
```

</details>


#### Expected after reimport (enabled / trust; `-` = key absent or blank):

| Evaluator | Realm attributes | Component (outdated) | Risk-based tab |
|-----------|------------------|----------------------|----------------|
| Known location | `true` / `0.75` | `true` / - | `true` / `0.75` |
| Browser | `false` / `0.5` | `true` / `0.99` | `false` / `0.5` |
| Login failures | `false` / `0.25` | `true` / `0.9` | `false` / `0.25` |
| Unusual login time | - / `0.8` | `true` / `0.1` | `true` / `0.8` |
| AI account takeover | `false` / `0.4` | `true` / - | `false` / `0.4` |
| Recaptcha | - / - | `true` / `0.3` | `true` / `1.0` |
| User actions | - / - | `false` / `0.2` | `true` / `1.0` |
| Operating system | - / - | `true` / - | `true` / `1.0` |
| Init location | - / - | - / - | `true` / `1.0` (then set `0.5`, save, reopen) |

Fixes #11

Thomas