### PR TITLE
fix(ui): preserve evaluator trust and enabled set by admin on save when realm attribute is already set

### DIFF
--- a/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
+++ b/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
@@ -225,9 +225,9 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
 
     /**
      * Aligns the component model with realm attributes before the form is rendered.
-     * Evaluator enabled/trust keys use non-blank realm attributes as source of truth; when absent,
-     * stale component config is cleared so schema defaults apply, matching runtime fallbacks.
-     * Other properties keep the component value when set, otherwise fall back to realm attributes.
+     * Evaluator enabled/trust keys use non-blank realm attributes as source of truth when loading the form.
+     * On save, an admin change to those keys is kept even if the realm attribute still holds the previous value.
+     * Other properties keep the submitted component value when set, otherwise fall back to realm attributes.
      */
     void hydrateModelFromRealmAttributes(RealmModel realm, ComponentModel model, ComponentModel persisted) {
         if (realm == null) {
@@ -237,14 +237,15 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
             var key = prop.getName();
             var realmValue = realm.getAttribute(key);
             if (isRealmSourcedEvaluatorSetting(key)) {
-                if (StringUtil.isNotBlank(realmValue)) {
+                var submitted = model.get(key);
+                if (isAdminSubmittedEvaluatorChange(persisted, key, submitted)) {
+                    logger.tracef("Keeping submitted evaluator setting '%s' = '%s' (admin change)", key, submitted);
+                } else if (StringUtil.isNotBlank(realmValue)) {
                     logger.tracef("Hydrating '%s' from realm attribute (evaluator setting)", key);
                     model.getConfig().putSingle(key, realmValue);
-                } else if (isUnchangedStaleComponentValue(persisted, key, model.get(key))) {
+                } else if (isUnchangedStaleComponentValue(persisted, key, submitted)) {
                     logger.tracef("Clearing stale component config for '%s' (no realm attribute)", key);
                     model.getConfig().remove(key);
-                } else if (isAdminSubmittedEvaluatorChange(persisted, key, model.get(key))) {
-                    logger.tracef("Keeping submitted evaluator setting '%s' = '%s' (no realm attribute yet)", key, model.get(key));
                 } else if (model.contains(key)) {
                     logger.tracef("Clearing evaluator setting '%s' (no realm attribute, not an admin change)", key);
                     model.getConfig().remove(key);

--- a/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
+++ b/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
@@ -294,6 +294,62 @@ class RiskBasedPoliciesUiTabPersistenceTest {
     }
 
     @Test
+    void validateConfiguration_preservesSubmittedTrustWhenRealmAttributeStillStale() {
+        var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
+        realmAttributes.put(trustKey, "0.75");
+        var persisted = tabComponent(Map.of(trustKey, "0.75"));
+        persisted.setId("risk-tab");
+        var model = componentModel(Map.of(trustKey, "1.0"));
+        model.setId("risk-tab");
+        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("1.0", model.get(trustKey));
+
+        tab.onUpdate(null, realm, persisted, model);
+
+        assertEquals("1.0", realmAttributes.get(trustKey));
+    }
+
+    @Test
+    void validateConfiguration_preservesSubmittedEnabledWhenRealmAttributeStillStale() {
+        var enabledKey = isEnabledConfig(BrowserRiskEvaluator.class);
+        realmAttributes.put(enabledKey, "false");
+        var persisted = tabComponent(Map.of(enabledKey, "false"));
+        persisted.setId("risk-tab");
+        var model = componentModel(Map.of(enabledKey, "true"));
+        model.setId("risk-tab");
+        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("true", model.get(enabledKey));
+
+        tab.onUpdate(null, realm, persisted, model);
+
+        assertEquals("true", realmAttributes.get(enabledKey));
+    }
+
+    @Test
+    void validateConfiguration_preservesSubmittedTimeoutWhenRealmAttributeStillStale() {
+        realmAttributes.put(EVALUATOR_TIMEOUT_CONFIG, "2500");
+        var persisted = tabComponent(Map.of(EVALUATOR_TIMEOUT_CONFIG, "2500"));
+        persisted.setId("risk-tab");
+        var model = componentModel(Map.of(EVALUATOR_TIMEOUT_CONFIG, "5000"));
+        model.setId("risk-tab");
+        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("5000", model.get(EVALUATOR_TIMEOUT_CONFIG));
+
+        tab.onUpdate(null, realm, persisted, model);
+
+        assertEquals("5000", realmAttributes.get(EVALUATOR_TIMEOUT_CONFIG));
+    }
+
+    @Test
     void onUpdate_persistsEvaluatorSettingsFromFormAfterStaleComponentCleared() {
         var trustKey = getTrustConfig(BrowserRiskEvaluator.class);
         var enabledKey = isEnabledConfig(BrowserRiskEvaluator.class);


### PR DESCRIPTION
@mabartos : This PR fixes a #73 regression (sorry) : evaluator trust and enabled could not be updated from the Risk-based policies tab once a realm attribute is set 🤡

## What's wrong

#73 made realm attributes the source of truth for display, fixing stale component config on form load. Tests focused on hydration edge cases and first-time saves, but missed the obvious path : changing an existing value (ex : trust 0.75 > 1) and saving.

On save, validateConfiguration runs **before** onUpdate and always re-hydrated from the realm attribute, overwriting the submitted value by admin.
onUpdate then persisted the old value. Direct onUpdate tests still passed.

## Fix
Treat an admin-submitted change as authoritative during validateConfiguration, before realm hydration + add non-regression tests