### PR TITLE
feat(client-role-risk-evaluator): score client roles via adaptive-client-role-riskScore attribute

### DIFF
--- a/EVALUATORS.md
+++ b/EVALUATORS.md
@@ -22,8 +22,8 @@ Executed after identifying the user during authentication (e.g. after username +
 | Evaluator | Description |
 |-----------|-------------|
 | AI account takeover | LLM behavioral analysis for account takeover (anonymized). |
-| Client role | Scores risk from the user's roles on the requesting OAuth client using built-in prefix heuristics (manage-*, create-*, view-*, query-*, and selected admin roles). |
-| Failed login pattern | Detects abnormal failed-login patterns for the user from login failure events. |
+| Client role | Scores risk from the user's assigned roles on the requesting OAuth client using the adaptive-client-role-riskScore attribute on each client role. Configure per role under Clients → Roles → Attributes. |
+| Failed login pattern | Detects distributed attack patterns and bot-like timing in login failure events. |
 | Known IP address | Scores whether the current IP was seen in the user's successful login history. New or rare IPs increase risk, familiar IPs can reduce it. |
 | Known location | Compares the current login location (GeoIP) to the user's known locations after identification. Requires location context, enable Init location if this evaluator is active. |
 | Login failures | Increases risk from recent LOGIN_ERROR events for the user (failure count, recency, and IP mismatch). Uses the Keycloak event store, not the brute-force counter. |

--- a/EVALUATORS.md
+++ b/EVALUATORS.md
@@ -22,7 +22,7 @@ Executed after identifying the user during authentication (e.g. after username +
 | Evaluator | Description |
 |-----------|-------------|
 | AI account takeover | LLM behavioral analysis for account takeover (anonymized). |
-| Client role | Scores risk from the user's assigned roles on the requesting OAuth client using the adaptive-client-role-riskScore attribute on each client role. Configure per role under Clients → Roles → Attributes. |
+| Client role | Scores risk from the user's assigned roles on the requesting OAuth client using Keycloak role-name prefix heuristics (manage-*, create-*, etc.). Override per role with adaptive-client-role-riskScore under Clients → Roles → Attributes. |
 | Failed login pattern | Detects distributed attack patterns and bot-like timing in login failure events. |
 | Known IP address | Scores whether the current IP was seen in the user's successful login history. New or rare IPs increase risk, familiar IPs can reduce it. |
 | Known location | Compares the current login location (GeoIP) to the user's known locations after identification. Requires location context, enable Init location if this evaluator is active. |

--- a/core/src/main/java/io/github/mabartos/docs/EvaluatorDocGenerator.java
+++ b/core/src/main/java/io/github/mabartos/docs/EvaluatorDocGenerator.java
@@ -63,6 +63,7 @@ public final class EvaluatorDocGenerator {
             out.println("# Risk Evaluators");
             out.println();
             out.println("> Auto-generated — do not edit manually.");
+            out.println("> Regenerate: `mvn -pl core compile exec:java@generate-evaluators-doc`");
             out.println();
 
             for (EvaluationPhase phase : EvaluationPhase.values()) {

--- a/core/src/main/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluator.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluator.java
@@ -7,32 +7,47 @@ import static io.github.mabartos.spi.evaluator.RiskEvaluator.EvaluationPhase.USE
 import io.github.mabartos.spi.level.Risk;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
-import org.keycloak.models.AdminRoles;
+import org.jboss.logging.Logger;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.utils.StringUtil;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
- * Risk evaluator based on the user's client roles for the target client.
+ * Risk evaluator for the OAuth client's roles at login
+ * ({@link io.github.mabartos.spi.evaluator.RiskEvaluator.EvaluationPhase#USER_KNOWN}).
  * <p>
- * Uses Keycloak's role naming convention to classify risk by prefix.
- * <p>
- * Users with no client roles on the target client receive a trust signal ({@link Risk.Score#NEGATIVE_LOW}).
+ * Scores the user's roles on the login OAuth client when at least one client role defines
+ * {@link #RISK_SCORE_ATTRIBUTE}. Role-name heuristics are not used.
+ * Configure per role via Admin Console: Clients → Roles → {role} → Attributes, or realm import / REST.
+ * <ul>
+ *   <li><strong>No active role attributes</strong> — returns {@link Risk.Score#INVALID} (no contribution).</li>
+ *   <li><strong>Active role attributes</strong> — {@link Risk#max(Risk)} over assigned roles with a scorable attribute;
+ *       roles without attribute or with explicit {@link Risk.Score#NONE} are ignored (WARN for unconfigured).
+ *       If none of the assigned roles contribute a score, returns {@link Risk.Score#INVALID}.</li>
+ *   <li><strong>Attributes set but unusable at runtime</strong> — returns {@link Risk.Score#INVALID} (WARN).</li>
+ *   <li>Missing attribute on a role — role ignored (WARN when assigned).</li>
+ *   <li>Explicit {@link Risk.Score#NONE} — intentional neutral, ignored for scoring.</li>
+ * </ul>
+ * The risk engine combines enabled evaluators according to realm <strong>Risk-based policies</strong>.
+ * Users with no client roles on the target client receive {@link Risk.Score#NEGATIVE_LOW} when role attributes are active.
  */
 @EvaluationPhase(USER_KNOWN)
 public class ClientRoleRiskEvaluator extends AbstractRiskEvaluator {
 
-    private static final String MANAGE_PREFIX = "manage-";
-    private static final String CREATE_PREFIX = "create-";
-    private static final String VIEW_PREFIX = "view-";
-    private static final String QUERY_PREFIX = "query-";
+    public static final String RISK_SCORE_ATTRIBUTE = "adaptive-client-role-riskScore";
 
-    private static final Set<String> SENSITIVE_ROLES = Set.of(AdminRoles.IMPERSONATION);
+    private static final Logger LOG = Logger.getLogger(ClientRoleRiskEvaluator.class);
 
     private final KeycloakSession session;
 
@@ -57,25 +72,165 @@ public class ClientRoleRiskEvaluator extends AbstractRiskEvaluator {
         }
 
         String clientId = client.getClientId();
-        Risk highest = Risk.of(Risk.Score.NEGATIVE_LOW, "User has no sensitive client roles on '%s'".formatted(clientId));
 
-        var roles = knownUser.getClientRoleMappingsStream(client).toList();
+        AttributeState attributes = getAttributeState(client);
+        if (!attributes.active()) {
+            if (attributes.unusable()) {
+                LOG.warnf(
+                        "ClientRoleRiskEvaluator skipped for client '%s': role risk attributes are set but could not be loaded",
+                        clientId);
+                return Risk.invalid(
+                        "Client role risk attributes are configured but could not be loaded for OAuth client '%s'"
+                                .formatted(clientId));
+            }
+            return Risk.invalid(
+                    "No active client role risk attributes for OAuth client '%s'".formatted(clientId));
+        }
 
-        for (RoleModel role : roles) {
-            Risk.Score score = scoreForRole(role.getName());
-            Risk current = Risk.of(score, "Client role '%s' on '%s'".formatted(role.getName(), clientId));
+        Map<String, Optional<Risk.Score>> assignedRoles = new LinkedHashMap<>();
+        knownUser.getClientRoleMappingsStream(client).forEach(role ->
+                assignedRoles.put(role.getName(), scoreFromRole(role)));
+
+        return evaluateAssignments(clientId, assignedRoles);
+    }
+
+    /**
+     * Scores assigned client roles. Keys are assigned role names; values are parsed role scores
+     * ({@link Optional#empty()} when the attribute is absent).
+     */
+    static Risk evaluateAssignments(String clientId, Map<String, Optional<Risk.Score>> assignedRoles) {
+        if (assignedRoles == null || assignedRoles.isEmpty()) {
+            return Risk.of(
+                    Risk.Score.NEGATIVE_LOW,
+                    "User has no client roles on '%s'".formatted(clientId));
+        }
+
+        List<String> unconfiguredRoles = new ArrayList<>();
+        List<String> neutralRoles = new ArrayList<>();
+        List<String> scoredRoles = new ArrayList<>();
+
+        for (Map.Entry<String, Optional<Risk.Score>> entry : assignedRoles.entrySet()) {
+            String roleName = entry.getKey();
+            Optional<Risk.Score> configured = entry.getValue();
+            if (configured.isEmpty()) {
+                unconfiguredRoles.add(roleName);
+                continue;
+            }
+            Risk.Score score = configured.get();
+            if (score == Risk.Score.NONE) {
+                neutralRoles.add(roleName);
+                continue;
+            }
+            scoredRoles.add(roleName);
+        }
+
+        if (scoredRoles.isEmpty()) {
+            List<String> ignored = new ArrayList<>(unconfiguredRoles);
+            ignored.addAll(neutralRoles);
+            LOG.warnf(
+                    "ClientRoleRiskEvaluator skipped for client '%s': no assigned role has a scorable '%s' "
+                            + "(ignored: %s)",
+                    clientId,
+                    RISK_SCORE_ATTRIBUTE,
+                    ignored);
+            return Risk.invalid(
+                    "No assigned client role has a scorable %s for OAuth client '%s' (ignored: %s)"
+                            .formatted(
+                                    RISK_SCORE_ATTRIBUTE,
+                                    clientId,
+                                    String.join(", ", ignored)));
+        }
+
+        if (!unconfiguredRoles.isEmpty()) {
+            LOG.warnf(
+                    "ClientRoleRiskEvaluator for client '%s': assigned role(s) without '%s' "
+                            + "(ignored, scoring configured roles only): %s",
+                    clientId,
+                    RISK_SCORE_ATTRIBUTE,
+                    unconfiguredRoles);
+        }
+
+        Risk highest = Risk.of(
+                Risk.Score.NEGATIVE_LOW,
+                "User has no sensitive client roles on '%s'".formatted(clientId));
+
+        for (String roleName : scoredRoles) {
+            Risk.Score score = assignedRoles.get(roleName).orElseThrow();
+            Risk current = Risk.of(score, "Client role '%s' on '%s'".formatted(roleName, clientId));
             highest = highest.max(current);
         }
 
         return highest;
     }
 
-    private Risk.Score scoreForRole(String roleName) {
-        if (SENSITIVE_ROLES.contains(roleName)) return Risk.Score.MEDIUM;
-        if (roleName.startsWith(MANAGE_PREFIX)) return Risk.Score.MEDIUM;
-        if (roleName.startsWith(CREATE_PREFIX)) return Risk.Score.SMALL;
-        if (roleName.startsWith(VIEW_PREFIX)) return Risk.Score.NONE;
-        if (roleName.startsWith(QUERY_PREFIX)) return Risk.Score.NONE;
-        return Risk.Score.NONE;
+    /**
+     * Snapshot of {@link #RISK_SCORE_ATTRIBUTE} presence and parseability across client roles.
+     */
+    record AttributeState(boolean configured, boolean active) {
+        static final AttributeState EMPTY = new AttributeState(false, false);
+
+        boolean unusable() {
+            return configured && !active;
+        }
+    }
+
+    static AttributeState getAttributeState(ClientModel client) {
+        if (client == null) {
+            return AttributeState.EMPTY;
+        }
+        Stream<RoleModel> roles = client.getRolesStream();
+        if (roles == null) {
+            return AttributeState.EMPTY;
+        }
+        Iterator<RoleModel> iterator = roles.iterator();
+        if (!iterator.hasNext()) {
+            return AttributeState.EMPTY;
+        }
+        boolean configured = false;
+        boolean active = false;
+        do {
+            RoleModel role = iterator.next();
+            if (!configured && roleDefinesRiskScore(role)) {
+                configured = true;
+            }
+            if (!active && scoreFromRole(role).isPresent()) {
+                active = true;
+            }
+        } while (iterator.hasNext() && !(configured && active));
+        return new AttributeState(configured, active);
+    }
+
+    static Optional<Risk.Score> scoreFromRole(RoleModel role) {
+        if (role == null) {
+            return Optional.empty();
+        }
+        String scoreRaw = role.getFirstAttribute(RISK_SCORE_ATTRIBUTE);
+        if (StringUtil.isBlank(scoreRaw)) {
+            return Optional.empty();
+        }
+        try {
+            Risk.Score score = Risk.Score.valueOf(scoreRaw.trim().toUpperCase());
+            if (score == Risk.Score.INVALID) {
+                LOG.warnf("Invalid client role risk score for role '%s' on client '%s': score INVALID is not allowed",
+                        role.getName(), clientIdForLog(role));
+                return Optional.empty();
+            }
+            return Optional.of(score);
+        } catch (IllegalArgumentException ex) {
+            LOG.warnf("Invalid client role risk score for role '%s' on client '%s': %s",
+                    role.getName(), clientIdForLog(role), ex.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private static boolean roleDefinesRiskScore(RoleModel role) {
+        return !StringUtil.isBlank(role.getFirstAttribute(RISK_SCORE_ATTRIBUTE));
+    }
+
+    private static String clientIdForLog(RoleModel role) {
+        if (role.getContainer() instanceof ClientModel client) {
+            return client.getClientId();
+        }
+        return "unknown";
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluator.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluator.java
@@ -8,6 +8,7 @@ import io.github.mabartos.spi.level.Risk;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.jboss.logging.Logger;
+import org.keycloak.models.AdminRoles;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -15,37 +16,35 @@ import org.keycloak.models.RoleModel;
 import org.keycloak.models.UserModel;
 import org.keycloak.utils.StringUtil;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.Set;
 
 /**
  * Risk evaluator for the OAuth client's roles at login
  * ({@link io.github.mabartos.spi.evaluator.RiskEvaluator.EvaluationPhase#USER_KNOWN}).
  * <p>
- * Scores the user's roles on the login OAuth client when at least one client role defines
- * {@link #RISK_SCORE_ATTRIBUTE}. Role-name heuristics are not used.
- * Configure per role via Admin Console: Clients → Roles → {role} → Attributes, or realm import / REST.
+ * Uses Keycloak's role naming convention to classify risk by prefix. Per-role attribute
+ * {@link #RISK_SCORE_ATTRIBUTE} overrides the prefix score when set.
+ * Configure via Admin Console: Clients → Roles → {role} → Attributes, or realm import / REST.
  * <ul>
- *   <li><strong>No active role attributes</strong> — returns {@link Risk.Score#INVALID} (no contribution).</li>
- *   <li><strong>Active role attributes</strong> — {@link Risk#max(Risk)} over assigned roles with a scorable attribute;
- *       roles without attribute or with explicit {@link Risk.Score#NONE} are ignored (WARN for unconfigured).
- *       If none of the assigned roles contribute a score, returns {@link Risk.Score#INVALID}.</li>
- *   <li><strong>Attributes set but unusable at runtime</strong> — returns {@link Risk.Score#INVALID} (WARN).</li>
- *   <li>Missing attribute on a role — role ignored (WARN when assigned).</li>
- *   <li>Explicit {@link Risk.Score#NONE} — intentional neutral, ignored for scoring.</li>
+ *   <li><strong>No attribute</strong> — prefix heuristics apply ({@code manage-*}, {@code create-*}, etc.).</li>
+ *   <li><strong>Attribute set</strong> — explicit score takes precedence over prefix heuristics.</li>
+ *   <li><strong>Explicit {@link Risk.Score#NONE}</strong> — intentional neutral override.</li>
+ *   <li><strong>Invalid attribute</strong> — WARN and fall back to prefix heuristics.</li>
  * </ul>
- * The risk engine combines enabled evaluators according to realm <strong>Risk-based policies</strong>.
- * Users with no client roles on the target client receive {@link Risk.Score#NEGATIVE_LOW} when role attributes are active.
+ * Users with no client roles on the target client receive a trust signal ({@link Risk.Score#NEGATIVE_LOW}).
  */
 @EvaluationPhase(USER_KNOWN)
 public class ClientRoleRiskEvaluator extends AbstractRiskEvaluator {
 
     public static final String RISK_SCORE_ATTRIBUTE = "adaptive-client-role-riskScore";
+
+    private static final String MANAGE_PREFIX = "manage-";
+    private static final String CREATE_PREFIX = "create-";
+    private static final String VIEW_PREFIX = "view-";
+    private static final String QUERY_PREFIX = "query-";
+
+    private static final Set<String> SENSITIVE_ROLES = Set.of(AdminRoles.IMPERSONATION);
 
     private static final Logger LOG = Logger.getLogger(ClientRoleRiskEvaluator.class);
 
@@ -72,91 +71,13 @@ public class ClientRoleRiskEvaluator extends AbstractRiskEvaluator {
         }
 
         String clientId = client.getClientId();
-
-        AttributeState attributes = getAttributeState(client);
-        if (!attributes.active()) {
-            if (attributes.unusable()) {
-                LOG.warnf(
-                        "ClientRoleRiskEvaluator skipped for client '%s': role risk attributes are set but could not be loaded",
-                        clientId);
-                return Risk.invalid(
-                        "Client role risk attributes are configured but could not be loaded for OAuth client '%s'"
-                                .formatted(clientId));
-            }
-            return Risk.invalid(
-                    "No active client role risk attributes for OAuth client '%s'".formatted(clientId));
-        }
-
-        Map<String, Optional<Risk.Score>> assignedRoles = new LinkedHashMap<>();
-        knownUser.getClientRoleMappingsStream(client).forEach(role ->
-                assignedRoles.put(role.getName(), scoreFromRole(role)));
-
-        return evaluateAssignments(clientId, assignedRoles);
-    }
-
-    /**
-     * Scores assigned client roles. Keys are assigned role names; values are parsed role scores
-     * ({@link Optional#empty()} when the attribute is absent).
-     */
-    static Risk evaluateAssignments(String clientId, Map<String, Optional<Risk.Score>> assignedRoles) {
-        if (assignedRoles == null || assignedRoles.isEmpty()) {
-            return Risk.of(
-                    Risk.Score.NEGATIVE_LOW,
-                    "User has no client roles on '%s'".formatted(clientId));
-        }
-
-        List<String> unconfiguredRoles = new ArrayList<>();
-        List<String> neutralRoles = new ArrayList<>();
-        List<String> scoredRoles = new ArrayList<>();
-
-        for (Map.Entry<String, Optional<Risk.Score>> entry : assignedRoles.entrySet()) {
-            String roleName = entry.getKey();
-            Optional<Risk.Score> configured = entry.getValue();
-            if (configured.isEmpty()) {
-                unconfiguredRoles.add(roleName);
-                continue;
-            }
-            Risk.Score score = configured.get();
-            if (score == Risk.Score.NONE) {
-                neutralRoles.add(roleName);
-                continue;
-            }
-            scoredRoles.add(roleName);
-        }
-
-        if (scoredRoles.isEmpty()) {
-            List<String> ignored = new ArrayList<>(unconfiguredRoles);
-            ignored.addAll(neutralRoles);
-            LOG.warnf(
-                    "ClientRoleRiskEvaluator skipped for client '%s': no assigned role has a scorable '%s' "
-                            + "(ignored: %s)",
-                    clientId,
-                    RISK_SCORE_ATTRIBUTE,
-                    ignored);
-            return Risk.invalid(
-                    "No assigned client role has a scorable %s for OAuth client '%s' (ignored: %s)"
-                            .formatted(
-                                    RISK_SCORE_ATTRIBUTE,
-                                    clientId,
-                                    String.join(", ", ignored)));
-        }
-
-        if (!unconfiguredRoles.isEmpty()) {
-            LOG.warnf(
-                    "ClientRoleRiskEvaluator for client '%s': assigned role(s) without '%s' "
-                            + "(ignored, scoring configured roles only): %s",
-                    clientId,
-                    RISK_SCORE_ATTRIBUTE,
-                    unconfiguredRoles);
-        }
-
         Risk highest = Risk.of(
                 Risk.Score.NEGATIVE_LOW,
                 "User has no sensitive client roles on '%s'".formatted(clientId));
 
-        for (String roleName : scoredRoles) {
-            Risk.Score score = assignedRoles.get(roleName).orElseThrow();
-            Risk current = Risk.of(score, "Client role '%s' on '%s'".formatted(roleName, clientId));
+        for (RoleModel role : knownUser.getClientRoleMappingsStream(client).toList()) {
+            Risk.Score score = scoreForRole(role);
+            Risk current = Risk.of(score, "Client role '%s' on '%s'".formatted(role.getName(), clientId));
             highest = highest.max(current);
         }
 
@@ -164,43 +85,20 @@ public class ClientRoleRiskEvaluator extends AbstractRiskEvaluator {
     }
 
     /**
-     * Snapshot of {@link #RISK_SCORE_ATTRIBUTE} presence and parseability across client roles.
+     * Resolves the effective score for a client role: explicit attribute overrides prefix heuristics.
      */
-    record AttributeState(boolean configured, boolean active) {
-        static final AttributeState EMPTY = new AttributeState(false, false);
-
-        boolean unusable() {
-            return configured && !active;
+    static Risk.Score scoreForRole(RoleModel role) {
+        if (role == null) {
+            return Risk.Score.NONE;
         }
+        return parseAttributeScore(role).orElseGet(() -> scoreFromRoleName(role.getName()));
     }
 
-    static AttributeState getAttributeState(ClientModel client) {
-        if (client == null) {
-            return AttributeState.EMPTY;
-        }
-        Stream<RoleModel> roles = client.getRolesStream();
-        if (roles == null) {
-            return AttributeState.EMPTY;
-        }
-        Iterator<RoleModel> iterator = roles.iterator();
-        if (!iterator.hasNext()) {
-            return AttributeState.EMPTY;
-        }
-        boolean configured = false;
-        boolean active = false;
-        do {
-            RoleModel role = iterator.next();
-            if (!configured && roleDefinesRiskScore(role)) {
-                configured = true;
-            }
-            if (!active && scoreFromRole(role).isPresent()) {
-                active = true;
-            }
-        } while (iterator.hasNext() && !(configured && active));
-        return new AttributeState(configured, active);
-    }
-
-    static Optional<Risk.Score> scoreFromRole(RoleModel role) {
+    /**
+     * Parses {@link #RISK_SCORE_ATTRIBUTE} when present. Empty when the attribute is absent;
+     * invalid values are logged and yield empty so callers fall back to prefix heuristics.
+     */
+    static Optional<Risk.Score> parseAttributeScore(RoleModel role) {
         if (role == null) {
             return Optional.empty();
         }
@@ -211,20 +109,37 @@ public class ClientRoleRiskEvaluator extends AbstractRiskEvaluator {
         try {
             Risk.Score score = Risk.Score.valueOf(scoreRaw.trim().toUpperCase());
             if (score == Risk.Score.INVALID) {
-                LOG.warnf("Invalid client role risk score for role '%s' on client '%s': score INVALID is not allowed",
+                LOG.warnf(
+                        "Invalid client role risk score for role '%s' on client '%s': score INVALID is not allowed",
                         role.getName(), clientIdForLog(role));
                 return Optional.empty();
             }
             return Optional.of(score);
         } catch (IllegalArgumentException ex) {
-            LOG.warnf("Invalid client role risk score for role '%s' on client '%s': %s",
+            LOG.warnf(
+                    "Invalid client role risk score for role '%s' on client '%s': %s",
                     role.getName(), clientIdForLog(role), ex.getMessage());
             return Optional.empty();
         }
     }
 
-    private static boolean roleDefinesRiskScore(RoleModel role) {
-        return !StringUtil.isBlank(role.getFirstAttribute(RISK_SCORE_ATTRIBUTE));
+    static Risk.Score scoreFromRoleName(String roleName) {
+        if (SENSITIVE_ROLES.contains(roleName)) {
+            return Risk.Score.MEDIUM;
+        }
+        if (roleName.startsWith(MANAGE_PREFIX)) {
+            return Risk.Score.MEDIUM;
+        }
+        if (roleName.startsWith(CREATE_PREFIX)) {
+            return Risk.Score.SMALL;
+        }
+        if (roleName.startsWith(VIEW_PREFIX)) {
+            return Risk.Score.NONE;
+        }
+        if (roleName.startsWith(QUERY_PREFIX)) {
+            return Risk.Score.NONE;
+        }
+        return Risk.Score.NONE;
     }
 
     private static String clientIdForLog(RoleModel role) {

--- a/core/src/main/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluatorFactory.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluatorFactory.java
@@ -25,11 +25,13 @@ public class ClientRoleRiskEvaluatorFactory implements RiskEvaluatorFactory {
 
     @Override
     public String getDescription() {
-        return "Scores risk from the user's roles on the requesting OAuth client using built-in prefix heuristics (manage-*, create-*, view-*, query-*, and selected admin roles).";
+        return "Scores risk from the user's assigned roles on the requesting OAuth client using the "
+                + ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE
+                + " attribute on each client role. Configure per role under Clients → Roles → Attributes.";
     }
 
     @Override
     public Class<? extends RiskEvaluator> evaluatorClass() {
-        return ClientRoleRiskEvaluator.class;   
+        return ClientRoleRiskEvaluator.class;
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluatorFactory.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluatorFactory.java
@@ -25,9 +25,10 @@ public class ClientRoleRiskEvaluatorFactory implements RiskEvaluatorFactory {
 
     @Override
     public String getDescription() {
-        return "Scores risk from the user's assigned roles on the requesting OAuth client using the "
+        return "Scores risk from the user's assigned roles on the requesting OAuth client using Keycloak "
+                + "role-name prefix heuristics (manage-*, create-*, etc.). Override per role with "
                 + ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE
-                + " attribute on each client role. Configure per role under Clients → Roles → Attributes.";
+                + " under Clients → Roles → Attributes.";
     }
 
     @Override

--- a/core/src/test/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluatorTest.java
+++ b/core/src/test/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluatorTest.java
@@ -1,0 +1,166 @@
+package io.github.mabartos.evaluator.client;
+
+import io.github.mabartos.spi.level.Risk;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.RoleModel;
+
+import java.lang.reflect.Proxy;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+class ClientRoleRiskEvaluatorTest {
+
+    @Test
+    void noAssignedRolesReturnsNegativeLow() {
+        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments("grafana", Map.of());
+        assertThat(risk.getScore(), is(Risk.Score.NEGATIVE_LOW));
+    }
+
+    @Test
+    void configuredRoleReturnsConfiguredScore() {
+        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments(
+                "grafana",
+                Map.of("admin", Optional.of(Risk.Score.HIGH)));
+        assertThat(risk.getScore(), is(Risk.Score.HIGH));
+    }
+
+    @Test
+    void soleUnconfiguredAssignedRoleReturnsInvalid() {
+        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments(
+                "grafana",
+                Map.of("viewer", Optional.empty()));
+        assertThat(risk.getScore(), is(Risk.Score.INVALID));
+        assertThat(risk.getReason().orElse(""), containsString("viewer"));
+        assertThat(risk.getReason().orElse(""), containsString(ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE));
+    }
+
+    @Test
+    void explicitNoneAssignedRoleReturnsInvalid() {
+        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments(
+                "grafana",
+                Map.of("viewer", Optional.of(Risk.Score.NONE)));
+        assertThat(risk.getScore(), is(Risk.Score.INVALID));
+        assertThat(risk.getReason().orElse(""), containsString("viewer"));
+    }
+
+    @Test
+    void partiallyConfiguredRolesUsesHighestScorableScore() {
+        Map<String, Optional<Risk.Score>> assigned = new LinkedHashMap<>();
+        assigned.put("viewer", Optional.of(Risk.Score.NONE));
+        assigned.put("editor", Optional.empty());
+        assigned.put("admin", Optional.of(Risk.Score.HIGH));
+
+        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments("grafana", assigned);
+        assertThat(risk.getScore(), is(Risk.Score.HIGH));
+    }
+
+    @Test
+    void scoreFromRole_returnsEmptyWhenNoAttribute() {
+        RoleModel role = role("admin", null);
+
+        assertThat(ClientRoleRiskEvaluator.scoreFromRole(role), is(Optional.empty()));
+    }
+
+    @Test
+    void scoreFromRole_parsesConfiguredScore() {
+        RoleModel role = role("admin", "negative_low");
+
+        assertThat(ClientRoleRiskEvaluator.scoreFromRole(role), is(Optional.of(Risk.Score.NEGATIVE_LOW)));
+    }
+
+    @Test
+    void scoreFromRole_parsesExplicitNone() {
+        RoleModel role = role("viewer", "NONE");
+
+        assertThat(ClientRoleRiskEvaluator.scoreFromRole(role), is(Optional.of(Risk.Score.NONE)));
+    }
+
+    @Test
+    void scoreFromRole_skipsInvalidScoreAtRuntime() {
+        RoleModel role = role("admin", "NOT_A_SCORE");
+
+        assertThat(ClientRoleRiskEvaluator.scoreFromRole(role), is(Optional.empty()));
+    }
+
+    @Test
+    void getAttributeState_activeWhenRoleHasExplicitNone() {
+        ClientModel client = clientWithRoles(Map.of("viewer", "NONE"));
+
+        ClientRoleRiskEvaluator.AttributeState state = ClientRoleRiskEvaluator.getAttributeState(client);
+        assertThat(state.configured(), is(true));
+        assertThat(state.active(), is(true));
+    }
+
+    @Test
+    void getAttributeState_emptyWhenClientHasNoRoles() {
+        ClientModel client = clientWithRoles(Map.of());
+
+        assertThat(ClientRoleRiskEvaluator.getAttributeState(client), is(ClientRoleRiskEvaluator.AttributeState.EMPTY));
+    }
+
+    @Test
+    void getAttributeState_unusableWhenAttributesExistButInvalid() {
+        ClientModel client = clientWithRoles(Map.of("admin", "NOT_A_SCORE"));
+
+        ClientRoleRiskEvaluator.AttributeState state = ClientRoleRiskEvaluator.getAttributeState(client);
+        assertThat(state.configured(), is(true));
+        assertThat(state.active(), is(false));
+        assertThat(state.unusable(), is(true));
+    }
+
+    private static RoleModel role(String name, String scoreRaw) {
+        return (RoleModel) Proxy.newProxyInstance(
+                RoleModel.class.getClassLoader(),
+                new Class[]{RoleModel.class},
+                (proxy, method, args) -> {
+                    if ("getName".equals(method.getName())) {
+                        return name;
+                    }
+                    if ("getFirstAttribute".equals(method.getName())
+                            && args.length == 1
+                            && ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE.equals(args[0])) {
+                        return scoreRaw;
+                    }
+                    Class<?> returnType = method.getReturnType();
+                    if (returnType == boolean.class) {
+                        return false;
+                    }
+                    if (returnType == int.class) {
+                        return 0;
+                    }
+                    if (returnType == long.class) {
+                        return 0L;
+                    }
+                    return null;
+                });
+    }
+
+    private static ClientModel clientWithRoles(Map<String, String> roleScores) {
+        return (ClientModel) Proxy.newProxyInstance(
+                ClientModel.class.getClassLoader(),
+                new Class[]{ClientModel.class},
+                (proxy, method, args) -> {
+                    if ("getRolesStream".equals(method.getName())) {
+                        return roleScores.entrySet().stream()
+                                .map(entry -> role(entry.getKey(), entry.getValue()));
+                    }
+                    Class<?> returnType = method.getReturnType();
+                    if (returnType == boolean.class) {
+                        return false;
+                    }
+                    if (returnType == int.class) {
+                        return 0;
+                    }
+                    if (returnType == long.class) {
+                        return 0L;
+                    }
+                    return null;
+                });
+    }
+}

--- a/core/src/test/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluatorTest.java
+++ b/core/src/test/java/io/github/mabartos/evaluator/client/ClientRoleRiskEvaluatorTest.java
@@ -2,116 +2,94 @@ package io.github.mabartos.evaluator.client;
 
 import io.github.mabartos.spi.level.Risk;
 import org.junit.jupiter.api.Test;
-import org.keycloak.models.ClientModel;
 import org.keycloak.models.RoleModel;
 
 import java.lang.reflect.Proxy;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 
 class ClientRoleRiskEvaluatorTest {
 
     @Test
-    void noAssignedRolesReturnsNegativeLow() {
-        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments("grafana", Map.of());
-        assertThat(risk.getScore(), is(Risk.Score.NEGATIVE_LOW));
+    void scoreFromRoleName_managePrefixReturnsMedium() {
+        assertThat(ClientRoleRiskEvaluator.scoreFromRoleName("manage-users"), is(Risk.Score.MEDIUM));
     }
 
     @Test
-    void configuredRoleReturnsConfiguredScore() {
-        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments(
-                "grafana",
-                Map.of("admin", Optional.of(Risk.Score.HIGH)));
-        assertThat(risk.getScore(), is(Risk.Score.HIGH));
+    void scoreFromRoleName_createPrefixReturnsSmall() {
+        assertThat(ClientRoleRiskEvaluator.scoreFromRoleName("create-client"), is(Risk.Score.SMALL));
     }
 
     @Test
-    void soleUnconfiguredAssignedRoleReturnsInvalid() {
-        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments(
-                "grafana",
-                Map.of("viewer", Optional.empty()));
-        assertThat(risk.getScore(), is(Risk.Score.INVALID));
-        assertThat(risk.getReason().orElse(""), containsString("viewer"));
-        assertThat(risk.getReason().orElse(""), containsString(ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE));
+    void scoreFromRoleName_viewPrefixReturnsNone() {
+        assertThat(ClientRoleRiskEvaluator.scoreFromRoleName("view-users"), is(Risk.Score.NONE));
     }
 
     @Test
-    void explicitNoneAssignedRoleReturnsInvalid() {
-        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments(
-                "grafana",
-                Map.of("viewer", Optional.of(Risk.Score.NONE)));
-        assertThat(risk.getScore(), is(Risk.Score.INVALID));
-        assertThat(risk.getReason().orElse(""), containsString("viewer"));
+    void scoreFromRoleName_unknownRoleReturnsNone() {
+        assertThat(ClientRoleRiskEvaluator.scoreFromRoleName("admin"), is(Risk.Score.NONE));
     }
 
     @Test
-    void partiallyConfiguredRolesUsesHighestScorableScore() {
-        Map<String, Optional<Risk.Score>> assigned = new LinkedHashMap<>();
-        assigned.put("viewer", Optional.of(Risk.Score.NONE));
-        assigned.put("editor", Optional.empty());
-        assigned.put("admin", Optional.of(Risk.Score.HIGH));
-
-        Risk risk = ClientRoleRiskEvaluator.evaluateAssignments("grafana", assigned);
-        assertThat(risk.getScore(), is(Risk.Score.HIGH));
+    void scoreFromRoleName_impersonationReturnsMedium() {
+        assertThat(ClientRoleRiskEvaluator.scoreFromRoleName("impersonation"), is(Risk.Score.MEDIUM));
     }
 
     @Test
-    void scoreFromRole_returnsEmptyWhenNoAttribute() {
+    void scoreForRole_usesPrefixWhenNoAttribute() {
+        RoleModel role = role("manage-reports", null);
+
+        assertThat(ClientRoleRiskEvaluator.scoreForRole(role), is(Risk.Score.MEDIUM));
+    }
+
+    @Test
+    void scoreForRole_attributeOverridesPrefix() {
+        RoleModel role = role("manage-reports", "NONE");
+
+        assertThat(ClientRoleRiskEvaluator.scoreForRole(role), is(Risk.Score.NONE));
+    }
+
+    @Test
+    void scoreForRole_attributeOverridesPrefixWithHigherScore() {
+        RoleModel role = role("viewer", "HIGH");
+
+        assertThat(ClientRoleRiskEvaluator.scoreForRole(role), is(Risk.Score.HIGH));
+    }
+
+    @Test
+    void parseAttributeScore_returnsEmptyWhenNoAttribute() {
         RoleModel role = role("admin", null);
 
-        assertThat(ClientRoleRiskEvaluator.scoreFromRole(role), is(Optional.empty()));
+        assertThat(ClientRoleRiskEvaluator.parseAttributeScore(role).isEmpty(), is(true));
     }
 
     @Test
-    void scoreFromRole_parsesConfiguredScore() {
+    void parseAttributeScore_parsesConfiguredScore() {
         RoleModel role = role("admin", "negative_low");
 
-        assertThat(ClientRoleRiskEvaluator.scoreFromRole(role), is(Optional.of(Risk.Score.NEGATIVE_LOW)));
+        assertThat(ClientRoleRiskEvaluator.parseAttributeScore(role), is(java.util.Optional.of(Risk.Score.NEGATIVE_LOW)));
     }
 
     @Test
-    void scoreFromRole_parsesExplicitNone() {
+    void parseAttributeScore_parsesExplicitNone() {
         RoleModel role = role("viewer", "NONE");
 
-        assertThat(ClientRoleRiskEvaluator.scoreFromRole(role), is(Optional.of(Risk.Score.NONE)));
+        assertThat(ClientRoleRiskEvaluator.parseAttributeScore(role), is(java.util.Optional.of(Risk.Score.NONE)));
     }
 
     @Test
-    void scoreFromRole_skipsInvalidScoreAtRuntime() {
+    void parseAttributeScore_skipsInvalidScoreAtRuntime() {
         RoleModel role = role("admin", "NOT_A_SCORE");
 
-        assertThat(ClientRoleRiskEvaluator.scoreFromRole(role), is(Optional.empty()));
+        assertThat(ClientRoleRiskEvaluator.parseAttributeScore(role).isEmpty(), is(true));
     }
 
     @Test
-    void getAttributeState_activeWhenRoleHasExplicitNone() {
-        ClientModel client = clientWithRoles(Map.of("viewer", "NONE"));
+    void scoreForRole_fallsBackToPrefixWhenAttributeInvalid() {
+        RoleModel role = role("manage-reports", "NOT_A_SCORE");
 
-        ClientRoleRiskEvaluator.AttributeState state = ClientRoleRiskEvaluator.getAttributeState(client);
-        assertThat(state.configured(), is(true));
-        assertThat(state.active(), is(true));
-    }
-
-    @Test
-    void getAttributeState_emptyWhenClientHasNoRoles() {
-        ClientModel client = clientWithRoles(Map.of());
-
-        assertThat(ClientRoleRiskEvaluator.getAttributeState(client), is(ClientRoleRiskEvaluator.AttributeState.EMPTY));
-    }
-
-    @Test
-    void getAttributeState_unusableWhenAttributesExistButInvalid() {
-        ClientModel client = clientWithRoles(Map.of("admin", "NOT_A_SCORE"));
-
-        ClientRoleRiskEvaluator.AttributeState state = ClientRoleRiskEvaluator.getAttributeState(client);
-        assertThat(state.configured(), is(true));
-        assertThat(state.active(), is(false));
-        assertThat(state.unusable(), is(true));
+        assertThat(ClientRoleRiskEvaluator.scoreForRole(role), is(Risk.Score.MEDIUM));
     }
 
     private static RoleModel role(String name, String scoreRaw) {
@@ -126,29 +104,6 @@ class ClientRoleRiskEvaluatorTest {
                             && args.length == 1
                             && ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE.equals(args[0])) {
                         return scoreRaw;
-                    }
-                    Class<?> returnType = method.getReturnType();
-                    if (returnType == boolean.class) {
-                        return false;
-                    }
-                    if (returnType == int.class) {
-                        return 0;
-                    }
-                    if (returnType == long.class) {
-                        return 0L;
-                    }
-                    return null;
-                });
-    }
-
-    private static ClientModel clientWithRoles(Map<String, String> roleScores) {
-        return (ClientModel) Proxy.newProxyInstance(
-                ClientModel.class.getClassLoader(),
-                new Class[]{ClientModel.class},
-                (proxy, method, args) -> {
-                    if ("getRolesStream".equals(method.getName())) {
-                        return roleScores.entrySet().stream()
-                                .map(entry -> role(entry.getKey(), entry.getValue()));
                     }
                     Class<?> returnType = method.getReturnType();
                     if (returnType == boolean.class) {

--- a/docs/realm-setup.md
+++ b/docs/realm-setup.md
@@ -70,7 +70,9 @@ No event on create, and no event on update when nothing changed.
 
 ### 3. Client role scores (`ClientRoleRiskEvaluator`, optional)
 
-Per client role, set attribute `adaptive-client-role-riskScore` (Admin Console: **Clients → {client} → Roles → {role} → Attributes**, or realm import / REST).
+By default, client roles are scored using Keycloak prefix heuristics (`manage-*` → `MEDIUM`, `create-*` → `SMALL`, `view-*` / `query-*` → `NONE`, etc.), consistent with realm role evaluation.
+
+To override a role's default score, set attribute `adaptive-client-role-riskScore` on the role (Admin Console: **Clients → {client} → Roles → {role} → Attributes**, or realm import / REST).
 
 | Attribute | Example |
 |-----------|---------|
@@ -78,8 +80,8 @@ Per client role, set attribute `adaptive-client-role-riskScore` (Admin Console: 
 
 Allowed values match `Risk.Score` (`VERY_SMALL`, `SMALL`, `NONE`, `LOW`, `MEDIUM`, `HIGH`, `VERY_HIGH`, `NEGATIVE_LOW`, etc.). `INVALID` is not allowed.
 
-- **Missing attribute** — role ignored at login (WARN if assigned).
-- **Explicit `NONE`** — intentional neutral; stored on the role as proof of configuration, ignored for scoring.
-- **No scorable assigned role** — `ClientRoleRiskEvaluator` returns `invalid` for that dimension.
+- **No attribute** — prefix heuristics apply.
+- **Attribute set** — explicit score overrides prefix heuristics for that role.
+- **Explicit `NONE`** — intentional neutral override (e.g. to neutralize a `manage-*` role on a custom app).
 
 Role scoring is evaluated at login only (`ClientRoleRiskEvaluator`, phase `USER_KNOWN`).

--- a/docs/realm-setup.md
+++ b/docs/realm-setup.md
@@ -67,3 +67,19 @@ On save, when at least one setting changed, one additional admin event is stored
 - detail value = `old > new` (e.g. `false > true`, `1500 > 2500`)
 
 No event on create, and no event on update when nothing changed.
+
+### 3. Client role scores (`ClientRoleRiskEvaluator`, optional)
+
+Per client role, set attribute `adaptive-client-role-riskScore` (Admin Console: **Clients → {client} → Roles → {role} → Attributes**, or realm import / REST).
+
+| Attribute | Example |
+|-----------|---------|
+| `adaptive-client-role-riskScore` | `HIGH` |
+
+Allowed values match `Risk.Score` (`VERY_SMALL`, `SMALL`, `NONE`, `LOW`, `MEDIUM`, `HIGH`, `VERY_HIGH`, `NEGATIVE_LOW`, etc.). `INVALID` is not allowed.
+
+- **Missing attribute** — role ignored at login (WARN if assigned).
+- **Explicit `NONE`** — intentional neutral; stored on the role as proof of configuration, ignored for scoring.
+- **No scorable assigned role** — `ClientRoleRiskEvaluator` returns `invalid` for that dimension.
+
+Role scoring is evaluated at login only (`ClientRoleRiskEvaluator`, phase `USER_KNOWN`).

--- a/tests/src/test/java/io/github/mabartos/ClientRoleRiskEvaluatorIT.java
+++ b/tests/src/test/java/io/github/mabartos/ClientRoleRiskEvaluatorIT.java
@@ -1,0 +1,300 @@
+package io.github.mabartos;
+
+import io.github.mabartos.evaluator.client.ClientRoleRiskEvaluator;
+import io.github.mabartos.spi.level.Risk;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
+import org.keycloak.testframework.annotations.InjectRealm;
+import org.keycloak.testframework.annotations.KeycloakIntegrationTest;
+import org.keycloak.testframework.injection.LifeCycle;
+import org.keycloak.testframework.realm.ManagedRealm;
+import org.keycloak.testframework.remote.runonserver.InjectRunOnServer;
+import org.keycloak.testframework.remote.runonserver.RunOnServerClient;
+import org.keycloak.testframework.server.KeycloakServerConfig;
+import org.keycloak.testframework.server.KeycloakServerConfigBuilder;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+@KeycloakIntegrationTest(config = ClientRoleRiskEvaluatorIT.Config.class)
+class ClientRoleRiskEvaluatorIT {
+
+    private static final String TEST_CLIENT_ID = "risk-role-client";
+
+    @InjectRealm(config = AdaptiveRealmConfig.class, ref = "adaptive", lifecycle = LifeCycle.CLASS)
+    ManagedRealm adaptiveRealm;
+
+    @InjectRunOnServer
+    RunOnServerClient runOnServer;
+
+    @Test
+    void evaluate_returnsConfiguredScoreForMappedClientRole() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("adaptive");
+            ClientModel client = requireTestClient(session, realm);
+            UserModel user = requireUser(session, realm);
+            var roleSnapshot = RoleAttributeSnapshot.capture(client);
+            var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
+            try {
+                setRoleScore(client, "admin", Risk.Score.HIGH);
+                grantClientRole(user, client, "admin");
+
+                withAuthSession(session, realm, client, () -> {
+                    Risk risk = new ClientRoleRiskEvaluator(session).evaluate(realm, user);
+                    assertThat(risk.getScore(), is(Risk.Score.HIGH));
+                    assertThat(risk.getReason().orElse(""), containsString("admin"));
+                });
+            } finally {
+                userRoleSnapshot.restore(user, client);
+                roleSnapshot.restore(client);
+            }
+        });
+    }
+
+    @Test
+    void evaluate_returnsInvalidWhenNoActiveRoleAttributes() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("adaptive");
+            ClientModel client = requireTestClient(session, realm);
+            UserModel user = requireUser(session, realm);
+            var roleSnapshot = RoleAttributeSnapshot.capture(client);
+            var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
+            try {
+                clearRoleRiskScores(client);
+                grantClientRole(user, client, "admin");
+
+                withAuthSession(session, realm, client, () -> {
+                    Risk risk = new ClientRoleRiskEvaluator(session).evaluate(realm, user);
+                    assertThat(risk.getScore(), is(Risk.Score.INVALID));
+                    assertThat(risk.getReason().orElse(""), containsString("No active client role risk attributes"));
+                });
+            } finally {
+                userRoleSnapshot.restore(user, client);
+                roleSnapshot.restore(client);
+            }
+        });
+    }
+
+    @Test
+    void evaluate_returnsNegativeLowWhenUserHasNoClientRoles() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("adaptive");
+            ClientModel client = requireTestClient(session, realm);
+            UserModel user = requireUser(session, realm);
+            var roleSnapshot = RoleAttributeSnapshot.capture(client);
+            var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
+            try {
+                setRoleScore(client, "admin", Risk.Score.HIGH);
+                revokeAllClientRoles(user, client);
+
+                withAuthSession(session, realm, client, () -> {
+                    Risk risk = new ClientRoleRiskEvaluator(session).evaluate(realm, user);
+                    assertThat(risk.getScore(), is(Risk.Score.NEGATIVE_LOW));
+                });
+            } finally {
+                userRoleSnapshot.restore(user, client);
+                roleSnapshot.restore(client);
+            }
+        });
+    }
+
+    @Test
+    void evaluate_usesMaxScoreAcrossMappedRoles() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("adaptive");
+            ClientModel client = requireTestClient(session, realm);
+            UserModel user = requireUser(session, realm);
+            var roleSnapshot = RoleAttributeSnapshot.capture(client);
+            var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
+            try {
+                setRoleScore(client, "admin", Risk.Score.HIGH);
+                setRoleScore(client, "viewer", Risk.Score.VERY_SMALL);
+                grantClientRole(user, client, "admin");
+                grantClientRole(user, client, "viewer");
+
+                withAuthSession(session, realm, client, () -> {
+                    Risk risk = new ClientRoleRiskEvaluator(session).evaluate(realm, user);
+                    assertThat(risk.getScore(), is(Risk.Score.HIGH));
+                });
+            } finally {
+                userRoleSnapshot.restore(user, client);
+                roleSnapshot.restore(client);
+            }
+        });
+    }
+
+    @Test
+    void evaluate_returnsInvalidWhenAssignedRoleHasNoScoreAttribute() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("adaptive");
+            ClientModel client = requireTestClient(session, realm);
+            UserModel user = requireUser(session, realm);
+            var roleSnapshot = RoleAttributeSnapshot.capture(client);
+            var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
+            try {
+                setRoleScore(client, "admin", Risk.Score.HIGH);
+                grantClientRole(user, client, "viewer");
+
+                withAuthSession(session, realm, client, () -> {
+                    Risk risk = new ClientRoleRiskEvaluator(session).evaluate(realm, user);
+                    assertThat(risk.getScore(), is(Risk.Score.INVALID));
+                    assertThat(risk.getReason().orElse(""), containsString("viewer"));
+                });
+            } finally {
+                userRoleSnapshot.restore(user, client);
+                roleSnapshot.restore(client);
+            }
+        });
+    }
+
+    @Test
+    void evaluate_returnsInvalidWhenAssignedRoleHasExplicitNoneOnly() {
+        runOnServer.run(session -> {
+            RealmModel realm = session.realms().getRealmByName("adaptive");
+            ClientModel client = requireTestClient(session, realm);
+            UserModel user = requireUser(session, realm);
+            var roleSnapshot = RoleAttributeSnapshot.capture(client);
+            var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
+            try {
+                setRoleScore(client, "admin", Risk.Score.HIGH);
+                setRoleScore(client, "viewer", Risk.Score.NONE);
+                grantClientRole(user, client, "viewer");
+
+                withAuthSession(session, realm, client, () -> {
+                    Risk risk = new ClientRoleRiskEvaluator(session).evaluate(realm, user);
+                    assertThat(risk.getScore(), is(Risk.Score.INVALID));
+                    assertThat(risk.getReason().orElse(""), containsString("viewer"));
+                });
+            } finally {
+                userRoleSnapshot.restore(user, client);
+                roleSnapshot.restore(client);
+            }
+        });
+    }
+
+    private static ClientModel requireTestClient(KeycloakSession session, RealmModel realm) {
+        ClientModel client = session.clients().getClientByClientId(realm, TEST_CLIENT_ID);
+        if (client == null) {
+            client = session.clients().addClient(realm, TEST_CLIENT_ID);
+            client.setEnabled(true);
+            client.setPublicClient(true);
+            client.setDirectAccessGrantsEnabled(true);
+            client.setProtocol("openid-connect");
+        }
+        requireClientRole(client, "admin");
+        requireClientRole(client, "viewer");
+        return client;
+    }
+
+    private static RoleModel requireClientRole(ClientModel client, String roleName) {
+        RoleModel role = client.getRole(roleName);
+        if (role == null) {
+            role = client.addRole(roleName);
+        }
+        return role;
+    }
+
+    private static UserModel requireUser(KeycloakSession session, RealmModel realm) {
+        UserModel user = session.users().getUserByUsername(realm, "user");
+        assertThat("Expected test user in adaptive realm", user != null, is(true));
+        return user;
+    }
+
+    private static void grantClientRole(UserModel user, ClientModel client, String roleName) {
+        user.grantRole(requireClientRole(client, roleName));
+    }
+
+    private static void revokeAllClientRoles(UserModel user, ClientModel client) {
+        user.getClientRoleMappingsStream(client).forEach(user::deleteRoleMapping);
+    }
+
+    private static void withAuthSession(
+            KeycloakSession session, RealmModel realm, ClientModel client, Runnable action) {
+        RootAuthenticationSessionModel root = session.authenticationSessions().createRootAuthenticationSession(realm);
+        try {
+            AuthenticationSessionModel authSession = root.createAuthenticationSession(client);
+            session.getContext().setRealm(realm);
+            session.getContext().setAuthenticationSession(authSession);
+            action.run();
+        } finally {
+            session.authenticationSessions().removeRootAuthenticationSession(realm, root);
+        }
+    }
+
+    private static void setRoleScore(ClientModel client, String roleName, Risk.Score score) {
+        requireClientRole(client, roleName).setSingleAttribute(
+                ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE, score.name());
+    }
+
+    private static void clearRoleRiskScores(ClientModel client) {
+        client.getRolesStream().forEach(role -> role.removeAttribute(ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE));
+    }
+
+    private static final class RoleAttributeSnapshot {
+        private final Map<String, String> roleScores;
+
+        private RoleAttributeSnapshot(Map<String, String> roleScores) {
+            this.roleScores = roleScores;
+        }
+
+        static RoleAttributeSnapshot capture(ClientModel client) {
+            Map<String, String> scores = new HashMap<>();
+            client.getRolesStream().forEach(role -> {
+                String score = role.getFirstAttribute(ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE);
+                if (score != null) {
+                    scores.put(role.getName(), score);
+                }
+            });
+            return new RoleAttributeSnapshot(scores);
+        }
+
+        void restore(ClientModel client) {
+            client.getRolesStream().forEach(role -> role.removeAttribute(ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE));
+            roleScores.forEach((roleName, score) ->
+                    requireClientRole(client, roleName).setSingleAttribute(
+                            ClientRoleRiskEvaluator.RISK_SCORE_ATTRIBUTE, score));
+        }
+    }
+
+    private static final class UserRoleSnapshot {
+        private final Set<String> roleNames;
+
+        private UserRoleSnapshot(Set<String> roleNames) {
+            this.roleNames = roleNames;
+        }
+
+        static UserRoleSnapshot capture(UserModel user, ClientModel client) {
+            Set<String> names = user.getClientRoleMappingsStream(client)
+                    .map(RoleModel::getName)
+                    .collect(Collectors.toCollection(HashSet::new));
+            return new UserRoleSnapshot(names);
+        }
+
+        void restore(UserModel user, ClientModel client) {
+            revokeAllClientRoles(user, client);
+            roleNames.forEach(roleName -> grantClientRole(user, client, roleName));
+        }
+    }
+
+    public static class Config implements KeycloakServerConfig {
+        @Override
+        public KeycloakServerConfigBuilder configure(KeycloakServerConfigBuilder builder) {
+            builder.log().categoryLevel("io.github.mabartos", "debug");
+            return builder.dependency("io.github.mabartos", "keycloak-adaptive-authn")
+                    .option("features", "declarative-ui");
+        }
+    }
+}

--- a/tests/src/test/java/io/github/mabartos/ClientRoleRiskEvaluatorIT.java
+++ b/tests/src/test/java/io/github/mabartos/ClientRoleRiskEvaluatorIT.java
@@ -65,7 +65,7 @@ class ClientRoleRiskEvaluatorIT {
     }
 
     @Test
-    void evaluate_returnsInvalidWhenNoActiveRoleAttributes() {
+    void evaluate_usesPrefixHeuristicsWhenNoAttribute() {
         runOnServer.run(session -> {
             RealmModel realm = session.realms().getRealmByName("adaptive");
             ClientModel client = requireTestClient(session, realm);
@@ -74,12 +74,13 @@ class ClientRoleRiskEvaluatorIT {
             var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
             try {
                 clearRoleRiskScores(client);
-                grantClientRole(user, client, "admin");
+                requireClientRole(client, "manage-reports");
+                grantClientRole(user, client, "manage-reports");
 
                 withAuthSession(session, realm, client, () -> {
                     Risk risk = new ClientRoleRiskEvaluator(session).evaluate(realm, user);
-                    assertThat(risk.getScore(), is(Risk.Score.INVALID));
-                    assertThat(risk.getReason().orElse(""), containsString("No active client role risk attributes"));
+                    assertThat(risk.getScore(), is(Risk.Score.MEDIUM));
+                    assertThat(risk.getReason().orElse(""), containsString("manage-reports"));
                 });
             } finally {
                 userRoleSnapshot.restore(user, client);
@@ -97,7 +98,6 @@ class ClientRoleRiskEvaluatorIT {
             var roleSnapshot = RoleAttributeSnapshot.capture(client);
             var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
             try {
-                setRoleScore(client, "admin", Risk.Score.HIGH);
                 revokeAllClientRoles(user, client);
 
                 withAuthSession(session, realm, client, () -> {
@@ -137,7 +137,7 @@ class ClientRoleRiskEvaluatorIT {
     }
 
     @Test
-    void evaluate_returnsInvalidWhenAssignedRoleHasNoScoreAttribute() {
+    void evaluate_attributeOverridesPrefixHeuristic() {
         runOnServer.run(session -> {
             RealmModel realm = session.realms().getRealmByName("adaptive");
             ClientModel client = requireTestClient(session, realm);
@@ -145,13 +145,14 @@ class ClientRoleRiskEvaluatorIT {
             var roleSnapshot = RoleAttributeSnapshot.capture(client);
             var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
             try {
-                setRoleScore(client, "admin", Risk.Score.HIGH);
-                grantClientRole(user, client, "viewer");
+                requireClientRole(client, "manage-reports");
+                setRoleScore(client, "manage-reports", Risk.Score.NONE);
+                grantClientRole(user, client, "manage-reports");
 
                 withAuthSession(session, realm, client, () -> {
                     Risk risk = new ClientRoleRiskEvaluator(session).evaluate(realm, user);
-                    assertThat(risk.getScore(), is(Risk.Score.INVALID));
-                    assertThat(risk.getReason().orElse(""), containsString("viewer"));
+                    assertThat(risk.getScore(), is(Risk.Score.NONE));
+                    assertThat(risk.getReason().orElse(""), containsString("manage-reports"));
                 });
             } finally {
                 userRoleSnapshot.restore(user, client);
@@ -161,7 +162,7 @@ class ClientRoleRiskEvaluatorIT {
     }
 
     @Test
-    void evaluate_returnsInvalidWhenAssignedRoleHasExplicitNoneOnly() {
+    void evaluate_usesPrefixScoreForUnconfiguredAssignedRole() {
         runOnServer.run(session -> {
             RealmModel realm = session.realms().getRealmByName("adaptive");
             ClientModel client = requireTestClient(session, realm);
@@ -169,14 +170,14 @@ class ClientRoleRiskEvaluatorIT {
             var roleSnapshot = RoleAttributeSnapshot.capture(client);
             var userRoleSnapshot = UserRoleSnapshot.capture(user, client);
             try {
-                setRoleScore(client, "admin", Risk.Score.HIGH);
-                setRoleScore(client, "viewer", Risk.Score.NONE);
-                grantClientRole(user, client, "viewer");
+                clearRoleRiskScores(client);
+                requireClientRole(client, "create-reports");
+                grantClientRole(user, client, "create-reports");
 
                 withAuthSession(session, realm, client, () -> {
                     Risk risk = new ClientRoleRiskEvaluator(session).evaluate(realm, user);
-                    assertThat(risk.getScore(), is(Risk.Score.INVALID));
-                    assertThat(risk.getReason().orElse(""), containsString("viewer"));
+                    assertThat(risk.getScore(), is(Risk.Score.SMALL));
+                    assertThat(risk.getReason().orElse(""), containsString("create-reports"));
                 });
             } finally {
                 userRoleSnapshot.restore(user, client);


### PR DESCRIPTION
Hello @mabartos,

Follow-up to #58 : first concrete proposal on configurable client-role criticality for `ClientRoleRiskEvaluator`.

This PR does not settle the broader questions from the discussion (`DefaultUserRoleEvaluator` scope, stacking with `ClientSensitivityRiskEvaluator`). It focuses on one slice : replace hardcoded role-name heuristics with explicit per-role configuration on the login OAuth client.

## What changes

`ClientRoleRiskEvaluator` reads `adaptive-client-role-riskScore` on each client role (Admin console : Clients → Roles → {role} → Attributes).

- Opt-in per client : the evaluator contributes only when at least one role on that client has a parseable attribute.
- At login : `Risk.max` over the user's assigned roles with a scorable score. Roles without the attribute or with explicit `NONE` are ignored.
- No client roles on the target client = `NEGATIVE_LOW` when attributes are active, but if no scorable assigned role = `INVALID`.

## Breaking change

Deployments that relied on built-in prefix heuristics (`manage-*`, `create-*`, etc.) must set `adaptive-client-riskScore` on relevant client roles

Thomas