### PR TITLE
feat(operating-system-risk-evaluator): treat legacy Windows as moderate OS risk

### DIFF
--- a/EVALUATORS.md
+++ b/EVALUATORS.md
@@ -12,7 +12,7 @@ Executed before the user is known. Useful for evaluating risk from browser, IP a
 | Browser | Scores the browser from the login request user agent. Chrome, Firefox, and Safari reduce risk, other browsers score moderate risk. |
 | Client sensitivity | Scores risk from the requesting OAuth client's sensitivity. Configure per client under Client → Risk-based settings. |
 | Init location | Prepares GeoIP/location context for later evaluators. |
-| Operating system | Scores the operating system from the login request user agent. |
+| Operating system | Scores the operating system from the login request user agent. Linux, macOS, and Windows 10/11 reduce risk, older Windows versions score moderate risk. |
 | reCAPTCHA | Uses Google reCAPTCHA Enterprise risk scores for the login attempt. |
 
 ## User Known (`USER_KNOWN`)

--- a/core/src/main/java/io/github/mabartos/context/os/OperatingSystemCondition.java
+++ b/core/src/main/java/io/github/mabartos/context/os/OperatingSystemCondition.java
@@ -54,8 +54,12 @@ public class OperatingSystemCondition implements UserContextCondition, Condition
         return OperatingSystemConditionFactory.isOs(realm, deviceContext, os);
     }
 
-    public boolean isDefaultKnownOs(RealmModel realmModel) {
-        return DefaultOperatingSystems.DEFAULT_OPERATING_SYSTEMS.stream().anyMatch(os -> isOs(realmModel, os));
+    public boolean isTrustedOs(RealmModel realm) {
+        return OperatingSystemConditionFactory.isTrustedOs(realm, deviceContext);
+    }
+
+    public boolean isLegacyWindows(RealmModel realm) {
+        return OperatingSystemConditionFactory.isLegacyWindows(realm, deviceContext);
     }
 
     @Override

--- a/core/src/main/java/io/github/mabartos/context/os/OperatingSystemConditionFactory.java
+++ b/core/src/main/java/io/github/mabartos/context/os/OperatingSystemConditionFactory.java
@@ -79,11 +79,58 @@ public class OperatingSystemConditionFactory extends UserContextConditionFactory
                 .build();
     }
 
+    /**
+     * Minimum Windows major version treated as a trust signal for risk scoring.
+     * Keycloak ua-parser maps {@code Windows NT 10.0} (Windows 10/11) to osVersion {@code "10"}.
+     */
+    static final int MIN_TRUSTED_WINDOWS_MAJOR = 10;
+
+    public static boolean isOs(DeviceRepresentation device, String os) {
+        return device != null && device.getOs() != null && device.getOs().startsWith(os);
+    }
+
     public static boolean isOs(RealmModel realm, DeviceRepresentationContext context, String os) {
         return context.getData(realm)
-                .map(DeviceRepresentation::getOs)
-                .map(f -> f.startsWith(os))
+                .map(device -> isOs(device, os))
                 .orElse(false);
+    }
+
+    public static boolean isTrustedOs(DeviceRepresentation device) {
+        return isOs(device, DefaultOperatingSystems.LINUX)
+                || isOs(device, DefaultOperatingSystems.MAC)
+                || isRecentWindows(device);
+    }
+
+    public static boolean isTrustedOs(RealmModel realm, DeviceRepresentationContext context) {
+        return context.getData(realm).map(OperatingSystemConditionFactory::isTrustedOs).orElse(false);
+    }
+
+    public static boolean isLegacyWindows(DeviceRepresentation device) {
+        return isOs(device, DefaultOperatingSystems.WINDOWS) && !isRecentWindows(device);
+    }
+
+    public static boolean isLegacyWindows(RealmModel realm, DeviceRepresentationContext context) {
+        return context.getData(realm).map(OperatingSystemConditionFactory::isLegacyWindows).orElse(false);
+    }
+
+    public static boolean isRecentWindows(DeviceRepresentation device) {
+        return isOs(device, DefaultOperatingSystems.WINDOWS)
+                && isRecentWindowsVersion(device.getOsVersion());
+    }
+
+    /**
+     * Parses the major segment of Keycloak {@link DeviceRepresentation#getOsVersion()}, as built by
+     * {@code DeviceRepresentationProviderImpl} from ua-parser ({@code major[.minor[.patch]]}).
+     */
+    public static boolean isRecentWindowsVersion(String osVersion) {
+        if (osVersion == null || osVersion.isBlank()) {
+            return false;
+        }
+        try {
+            return Integer.parseInt(osVersion.split("\\.", 2)[0]) >= MIN_TRUSTED_WINDOWS_MAJOR;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     protected static boolean isOsSpecified(RealmModel realm, DeviceRepresentationContext device, List<String> specifiedSystems) {

--- a/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemRiskEvaluator.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemRiskEvaluator.java
@@ -17,6 +17,7 @@
 package io.github.mabartos.evaluator.os;
 
 import io.github.mabartos.context.UserContexts;
+import io.github.mabartos.context.os.DefaultOperatingSystems;
 import io.github.mabartos.context.os.OperatingSystemCondition;
 import io.github.mabartos.context.os.OperatingSystemConditionFactory;
 import io.github.mabartos.spi.evaluator.EvaluationPhase;
@@ -32,8 +33,8 @@ import static io.github.mabartos.spi.level.Risk.Score.MEDIUM;
 import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
 
 /**
- * Risk evaluator for OS properties
- * Known OS = trust signal, unknown OS = moderate risk
+ * Risk evaluator for OS properties.
+ * Linux, macOS, and recent Windows (10/11) reduce risk; legacy Windows and unknown OS score moderate risk.
  */
 @EvaluationPhase(BEFORE_AUTHN)
 public class OperatingSystemRiskEvaluator extends DeviceRiskEvaluator {
@@ -45,8 +46,15 @@ public class OperatingSystemRiskEvaluator extends DeviceRiskEvaluator {
 
     @Override
     public Risk evaluate(@Nonnull RealmModel realm) {
-        return condition.isDefaultKnownOs(realm)
-            ? Risk.of(NEGATIVE_LOW, "Known OS - trust signal")
-            : Risk.of(MEDIUM, "Unknown OS");
+        if (condition.isTrustedOs(realm)) {
+            if (condition.isOs(realm, DefaultOperatingSystems.WINDOWS)) {
+                return Risk.of(NEGATIVE_LOW, "Recent Windows - trust signal");
+            }
+            return Risk.of(NEGATIVE_LOW, "Known OS - trust signal");
+        }
+        if (condition.isLegacyWindows(realm)) {
+            return Risk.of(MEDIUM, "Legacy Windows");
+        }
+        return Risk.of(MEDIUM, "Unknown OS");
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemRiskEvaluatorFactory.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemRiskEvaluatorFactory.java
@@ -41,7 +41,7 @@ public class OperatingSystemRiskEvaluatorFactory implements RiskEvaluatorFactory
 
     @Override
     public String getDescription() {
-        return "Scores the operating system from the login request user agent.";
+        return "Scores the operating system from the login request user agent. Linux, macOS, and Windows 10/11 reduce risk, older Windows versions score moderate risk.";
     }
 
     @Override

--- a/core/src/test/java/io/github/mabartos/context/os/OperatingSystemConditionFactoryTest.java
+++ b/core/src/test/java/io/github/mabartos/context/os/OperatingSystemConditionFactoryTest.java
@@ -1,0 +1,63 @@
+package io.github.mabartos.context.os;
+
+import org.junit.jupiter.api.Test;
+import org.keycloak.representations.account.DeviceRepresentation;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Device OS values mirror Keycloak {@code DeviceRepresentationProviderImpl} + ua-parser output.
+ */
+class OperatingSystemConditionFactoryTest {
+
+    // DeviceRepresentationProviderImpl: Windows NT 10.0 -> osVersion "10"
+    private static final DeviceRepresentation WINDOWS_10 = keycloakDevice("Windows", "10");
+    private static final DeviceRepresentation WINDOWS_7 = keycloakDevice("Windows", "7");
+    private static final DeviceRepresentation WINDOWS_81 = keycloakDevice("Windows", "8.1");
+    private static final DeviceRepresentation LINUX = keycloakDevice("Linux", null);
+    private static final DeviceRepresentation MAC = keycloakDevice("Mac OS X", "10.15.7");
+
+    @Test
+    void recentWindowsVersionMatchesKeycloakNt10Output() {
+        assertTrue(OperatingSystemConditionFactory.isRecentWindowsVersion("10"));
+        assertTrue(OperatingSystemConditionFactory.isRecentWindowsVersion("10.0"));
+        assertFalse(OperatingSystemConditionFactory.isRecentWindowsVersion("7"));
+        assertFalse(OperatingSystemConditionFactory.isRecentWindowsVersion("8.1"));
+        assertFalse(OperatingSystemConditionFactory.isRecentWindowsVersion(null));
+    }
+
+    @Test
+    void trustedOsFromKeycloakDeviceRepresentation() {
+        assertTrue(OperatingSystemConditionFactory.isTrustedOs(WINDOWS_10));
+        assertTrue(OperatingSystemConditionFactory.isTrustedOs(LINUX));
+        assertTrue(OperatingSystemConditionFactory.isTrustedOs(MAC));
+    }
+
+    @Test
+    void legacyWindowsFromKeycloakDeviceRepresentation() {
+        assertTrue(OperatingSystemConditionFactory.isLegacyWindows(WINDOWS_7));
+        assertTrue(OperatingSystemConditionFactory.isLegacyWindows(WINDOWS_81));
+        assertFalse(OperatingSystemConditionFactory.isLegacyWindows(WINDOWS_10));
+    }
+
+    @Test
+    void macOsMatchesDefaultPrefix() {
+        assertTrue(OperatingSystemConditionFactory.isOs(MAC, DefaultOperatingSystems.MAC));
+    }
+
+    @Test
+    void unknownOsIsNotTrustedOrLegacyWindows() {
+        DeviceRepresentation android = keycloakDevice("Android", "14");
+
+        assertFalse(OperatingSystemConditionFactory.isTrustedOs(android));
+        assertFalse(OperatingSystemConditionFactory.isLegacyWindows(android));
+    }
+
+    private static DeviceRepresentation keycloakDevice(String os, String osVersion) {
+        DeviceRepresentation device = new DeviceRepresentation();
+        device.setOs(os);
+        device.setOsVersion(osVersion);
+        return device;
+    }
+}


### PR DESCRIPTION
Hello,

- Score Windows 10/11 (ua-parser major `>= 10`) as a trust signal, older Windows versions score moderate risk.
- Linux and macOS behavior unchanged.

Thomas