### PR TITLE
feat(ip-api): add MaxMind GeoLite2-City local GeoIP resolver

### DIFF
--- a/extensions/ip-api/README.md
+++ b/extensions/ip-api/README.md
@@ -1,6 +1,6 @@
 # IP API Location Extension
 
-Location context provider for [Keycloak Adaptive Authentication](../../README.md) that resolves geolocation data from client IP via configurable providers ([ipapi.co](https://ipapi.co/), [ip-api.com](https://ip-api.com/)).
+Location context provider for [Keycloak Adaptive Authentication](../../README.md) that resolves geolocation data from client IP via configurable providers ([ipapi.co](https://ipapi.co/), [ip-api.com](https://ip-api.com/), [MaxMind GeoLite2](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data/)).
 
 ## What it does
 
@@ -40,6 +40,10 @@ Configuration is done exclusively through environment variables. Set them on you
 | `KC_ADAPTIVE_LOCATION_PROVIDERS` | Comma-separated GeoIP resolver ids (try order) | No | `ipapi-co-free` |
 | `KC_ADAPTIVE_IPAPI_TOKEN` | API token for [ipapi.co](https://ipapi.co/) | For `ipapi-co-pro` | _(none)_ |
 | `KC_ADAPTIVE_IP_API_COM_API_KEY` | Pro API key for [ip-api.com](https://ip-api.com) | For `ip-api-com-pro` | _(none)_ |
+| `KC_ADAPTIVE_MAXMIND_ACCOUNT_ID` | MaxMind account ID | For official MaxMind download | _(none)_ |
+| `KC_ADAPTIVE_MAXMIND_LICENSE_KEY` | MaxMind license key | For official MaxMind download | _(none)_ |
+| `KC_ADAPTIVE_MAXMIND_DB_REFRESH_INTERVAL` | ISO-8601 duration between GeoLite2-City refreshes | No | `PT7D` |
+| `KC_ADAPTIVE_MAXMIND_DB_PATH` | Local path for `GeoLite2-City.mmdb` | No | `{kc.data-dir}/adaptive-authn/geolite2/GeoLite2-City.mmdb` |
 
 **Resolver ids:**
 
@@ -49,12 +53,13 @@ Configuration is done exclusively through environment variables. Set them on you
 | `ipapi-co-pro` | ipapi.co | Requires `KC_ADAPTIVE_IPAPI_TOKEN` |
 | `ip-api-com-free` | ip-api.com | ⚠️ HTTP only — dev/non-prod |
 | `ip-api-com-pro` | ip-api.com | requires `KC_ADAPTIVE_IP_API_COM_API_KEY` |
+| `maxmind` | GeoLite2-City (local MMDB) | No per-lookup HTTP; see MaxMind section below |
 
 If every resolver fails, no location is returned (not cached). Location conditions then use `<unknown>` for country/city.
 
 ⚠️ **`ip-api-com-free`** uses plain HTTP. Prefer `ip-api-com-pro` or `ipapi-co-*` in production.
 
-**Example (Docker):**
+**Example (Docker, HTTP providers):**
 
 ```shell
 docker run ... \
@@ -62,6 +67,45 @@ docker run ... \
   -e KC_ADAPTIVE_IPAPI_TOKEN=your_ipapi_token \
   -e KC_ADAPTIVE_IP_API_COM_API_KEY=your_ip_api_com_key ...
 ```
+
+**Example (MaxMind, production):**
+
+```shell
+docker run ... \
+  -e KC_ADAPTIVE_LOCATION_PROVIDERS=maxmind \
+  -e KC_ADAPTIVE_MAXMIND_ACCOUNT_ID=123456 \
+  -e KC_ADAPTIVE_MAXMIND_LICENSE_KEY=your_license_key
+```
+
+**Example (MaxMind, POC without MaxMind account):**
+
+```shell
+docker run ... \
+  -e KC_ADAPTIVE_LOCATION_PROVIDERS=maxmind
+```
+
+Without MaxMind credentials, the extension downloads GeoLite2-City from the [P3TERX community mirror](https://github.com/P3TERX/GeoLite.mmdb) at startup. This is convenient for quick testing but **not** compliant with the [GeoLite2 EULA](https://www.maxmind.com/en/geolite2/eula) for production; use official credentials in prod.
+
+**Example (mixed fallback):**
+
+```shell
+docker run ... \
+  -e KC_ADAPTIVE_LOCATION_PROVIDERS=maxmind,ipapi-co-free
+```
+
+### MaxMind database lifecycle
+
+When `maxmind` is listed in `KC_ADAPTIVE_LOCATION_PROVIDERS`:
+
+1. On Keycloak startup, the extension checks for a local `GeoLite2-City.mmdb` at `KC_ADAPTIVE_MAXMIND_DB_PATH` (or the default under `kc.data-dir`).
+2. If the file is missing or older than `KC_ADAPTIVE_MAXMIND_DB_REFRESH_INTERVAL`, it downloads a fresh copy:
+   - **Official** (both `KC_ADAPTIVE_MAXMIND_ACCOUNT_ID` and `KC_ADAPTIVE_MAXMIND_LICENSE_KEY` set): from `download.maxmind.com`
+   - **Mirror** (no credentials): from the P3TERX GitHub repository
+3. A background task re-checks and refreshes the database on the configured interval.
+
+GeoLite2-City is updated by MaxMind twice weekly (Tuesday and Friday). The default refresh interval of 7 days keeps the database current within the EULA's 30-day requirement.
+
+Lookups are performed locally via the [GeoIP2 Java API](https://github.com/maxmind/GeoIP2-java); no external HTTP call is made per authentication request.
 
 ### Note on configuration
 
@@ -82,20 +126,20 @@ The core module provides additional location-related settings that affect all lo
 
 ## Location data
 
-The extension resolves the following fields from providers :
+The extension resolves the following fields from providers:
 
-| Field | Example |
-|---|---|
-| City | `Prague` |
-| Region | `Hlavni mesto Praha` |
-| Region code | `10` |
-| Country | `Czechia` |
-| Continent | `EU` |
-| Postal code | `110 00` |
-| Latitude | `50.0833` |
-| Longitude | `14.4167` |
-| Timezone | `Europe/Prague` |
-| Currency | `CZK` |
+| Field | Example | MaxMind (`maxmind`) |
+|---|---|---|
+| City | `Prague` | ✅ |
+| Region | `Hlavni mesto Praha` | ✅ |
+| Region code | `10` | ✅ |
+| Country | `Czechia` | ✅ |
+| Continent | `EU` | ✅ |
+| Postal code | `110 00` | ✅ (when available) |
+| Latitude | `50.0833` | ✅ |
+| Longitude | `14.4167` | ✅ |
+| Timezone | `Europe/Prague` | ✅ |
+| Currency | `CZK` | ❌ (not in GeoLite2-City) |
 
 ## Architecture
 
@@ -105,11 +149,13 @@ IpApiLocationContextFactory (UserContext SPI)
         ├── Uses IpAddressContext to get client IP
         └── GeoIpResolverChain (order from KC_ADAPTIVE_LOCATION_PROVIDERS)
               └── GeoIpResolver SPI providers (registered at build; pro tiers gated at runtime on credentials)
-                    ├── ipapi-co-free / ipapi-co-pro   → IpApiCoGeoIpResolver
-                    └── ip-api-com-free / ip-api-com-pro → IpApiComGeoIpResolver
+                    ├── ipapi-co-free / ipapi-co-pro      → IpApiCoGeoIpResolver (HTTP)
+                    ├── ip-api-com-free / ip-api-com-pro  → IpApiComGeoIpResolver (HTTP)
+                    └── maxmind                           → MaxMindGeoIpResolver (local MMDB)
+                              └── MaxMindDatabaseManager (download + scheduled refresh)
 ```
 
-Each backend is a separate `GeoIpResolverFactory` in this extension JAR (`io.github.mabartos.context.location.geoip`). Pro tiers are skipped at runtime when their credential env var is unset (factories stay registered so a Keycloak rebuild is not required when secrets are supplied only at container start). Future backends (e.g. MaxMind) can ship as additional extension JARs registering the same SPI.
+Each backend is a separate `GeoIpResolverFactory` in this extension JAR. Pro HTTP tiers are skipped at runtime when their credential env var is unset (factories stay registered so a Keycloak rebuild is not required when secrets are supplied only at container start). The MaxMind resolver works without credentials (community mirror) or with official MaxMind credentials for production downloads.
 
 ## Community maintainer
 - [Thomas DELORGE](https://github.com/thomasdelorge)

--- a/extensions/ip-api/pom.xml
+++ b/extensions/ip-api/pom.xml
@@ -12,6 +12,11 @@
     <artifactId>keycloak-adaptive-ext-ip-api</artifactId>
     <name>Keycloak Adaptive Authentication Extension: IP API</name>
 
+    <properties>
+        <geoip2.version>5.1.0</geoip2.version>
+        <commons-compress.version>1.27.1</commons-compress.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.github.mabartos</groupId>
@@ -35,11 +40,80 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.maxmind.geoip2</groupId>
+            <artifactId>geoip2</artifactId>
+            <version>${geoip2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons-compress.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.keycloak.testframework</groupId>
             <artifactId>keycloak-test-framework-core</artifactId>
             <version>${keycloak.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>${maven.plugins.download.version}</version>
+                <executions>
+                    <execution>
+                        <id>download-geolite2-city-test-mmdb</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://github.com/maxmind/MaxMind-DB/raw/main/test-data/GeoLite2-City-Test.mmdb</url>
+                            <outputDirectory>${project.build.testOutputDirectory}/maxmind</outputDirectory>
+                            <outputFileName>GeoLite2-City-Test.mmdb</outputFileName>
+                            <followRedirects>true</followRedirects>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven.plugins.shade.version}</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>com.maxmind.geoip2:geoip2</include>
+                                    <include>com.maxmind.db:maxmind-db</include>
+                                    <include>org.apache.commons:commons-compress</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/IpApiLocationContextFactory.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/IpApiLocationContextFactory.java
@@ -38,9 +38,12 @@ import java.util.List;
  *   <li>{@link io.github.mabartos.context.location.geoip.AdaptiveConfig#LOCATION_PROVIDERS_PROPERTY} — comma-separated resolver ids (try order).
  *       Default: {@value GeoIpResolverIds#IPAPI_CO_FREE}, or {@value GeoIpResolverIds#IPAPI_CO_PRO}
  *       when {@link io.github.mabartos.context.location.geoip.AdaptiveConfig#IPAPI_TOKEN_PROPERTY} is set and providers were not configured.</li>
- *   <li>Known ids: {@code ipapi-co-free}, {@code ipapi-co-pro}, {@code ip-api-com-free}, {@code ip-api-com-pro}.</li>
+ *   <li>Known ids: {@code ipapi-co-free}, {@code ipapi-co-pro}, {@code ip-api-com-free}, {@code ip-api-com-pro}, {@code maxmind}.</li>
  *   <li>{@link io.github.mabartos.context.location.geoip.AdaptiveConfig#IPAPI_TOKEN_PROPERTY} — required for {@code ipapi-co-pro}.</li>
  *   <li>{@link IpApiComGeoIpResolverProFactory#API_KEY_PROPERTY} — required for {@code ip-api-com-pro}.</li>
+ *   <li>{@link io.github.mabartos.context.location.geoip.AdaptiveConfig#MAXMIND_ACCOUNT_ID_PROPERTY} and
+ *       {@link io.github.mabartos.context.location.geoip.AdaptiveConfig#MAXMIND_LICENSE_KEY_PROPERTY} — optional for
+ *       {@code maxmind}; when both are set, the GeoLite2-City database is downloaded from MaxMind's official API.</li>
  *   <li>If every resolver fails, {@link IpApiLocationContext} returns {@link java.util.Optional#empty()}
  *       (not cached, ERROR logged).</li>
  * </ul>

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/geoip/AdaptiveConfig.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/geoip/AdaptiveConfig.java
@@ -2,6 +2,8 @@ package io.github.mabartos.context.location.geoip;
 
 import org.keycloak.quarkus.runtime.configuration.Configuration;
 
+import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Optional;
 
 /**
@@ -21,6 +23,20 @@ public final class AdaptiveConfig {
     /** {@code KC_ADAPTIVE_IP_API_COM_API_KEY} */
     public static final String IP_API_COM_API_KEY_PROPERTY = "kc.adaptive-ip-api-com-api-key";
 
+    /** {@code KC_ADAPTIVE_MAXMIND_ACCOUNT_ID} */
+    public static final String MAXMIND_ACCOUNT_ID_PROPERTY = "kc.adaptive-maxmind-account-id";
+
+    /** {@code KC_ADAPTIVE_MAXMIND_LICENSE_KEY} */
+    public static final String MAXMIND_LICENSE_KEY_PROPERTY = "kc.adaptive-maxmind-license-key";
+
+    /** {@code KC_ADAPTIVE_MAXMIND_DB_REFRESH_INTERVAL} */
+    public static final String MAXMIND_DB_REFRESH_INTERVAL_PROPERTY = "kc.adaptive-maxmind-db-refresh-interval";
+
+    /** {@code KC_ADAPTIVE_MAXMIND_DB_PATH} */
+    public static final String MAXMIND_DB_PATH_PROPERTY = "kc.adaptive-maxmind-db-path";
+
+    private static final Duration DEFAULT_MAXMIND_DB_REFRESH_INTERVAL = Duration.ofDays(7);
+
     private AdaptiveConfig() {
     }
 
@@ -34,6 +50,46 @@ public final class AdaptiveConfig {
 
     public static Optional<String> ipApiComApiKey() {
         return getOptionalValue(IP_API_COM_API_KEY_PROPERTY);
+    }
+
+    public static Optional<String> maxMindAccountId() {
+        return getOptionalValue(MAXMIND_ACCOUNT_ID_PROPERTY);
+    }
+
+    public static Optional<String> maxMindLicenseKey() {
+        return getOptionalValue(MAXMIND_LICENSE_KEY_PROPERTY);
+    }
+
+    public static Duration maxMindDbRefreshInterval() {
+        return getOptionalValue(MAXMIND_DB_REFRESH_INTERVAL_PROPERTY)
+                .map(AdaptiveConfig::parseDuration)
+                .filter(duration -> !duration.isNegative() && !duration.isZero())
+                .orElse(DEFAULT_MAXMIND_DB_REFRESH_INTERVAL);
+    }
+
+    public static Path maxMindDbPath() {
+        return maxMindDbPathOptional().orElseGet(AdaptiveConfig::defaultMaxMindDbPath);
+    }
+
+    public static Optional<Path> maxMindDbPathOptional() {
+        return getOptionalValue(MAXMIND_DB_PATH_PROPERTY).map(Path::of);
+    }
+
+    public static boolean maxMindOfficialCredentialsPresent() {
+        return maxMindAccountId().isPresent() && maxMindLicenseKey().isPresent();
+    }
+
+    public static boolean maxMindPartialCredentialsPresent() {
+        return maxMindAccountId().isPresent() ^ maxMindLicenseKey().isPresent();
+    }
+
+    private static Path defaultMaxMindDbPath() {
+        String dataDir = getOptionalValue("kc.data-dir").orElse(System.getProperty("java.io.tmpdir"));
+        return Path.of(dataDir, "adaptive-authn", "geolite2", "GeoLite2-City.mmdb");
+    }
+
+    private static Duration parseDuration(String raw) {
+        return Duration.parse(raw.trim());
     }
 
     private static Optional<String> getOptionalValue(String key) {

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/geoip/GeoIpResolverChain.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/geoip/GeoIpResolverChain.java
@@ -131,6 +131,16 @@ public final class GeoIpResolverChain {
     }
 
     /**
+     * True when {@code providerId} appears in the configured provider list (CSV parsing + legacy migration rules).
+     */
+    public static boolean isProviderConfigured(String providerId) {
+        String configured = readConfiguredProviders();
+        String ipApiToken = readIpApiToken();
+        String raw = resolveProvidersForMigration(configured, isProvidersExplicitlyConfigured(configured), ipApiToken);
+        return parseOrderedProviderIds(raw).contains(providerId);
+    }
+
+    /**
      * Parses comma-separated provider ids (lower-cased, blanks skipped).
      */
     static List<String> parseOrderedProviderIds(String providersRaw) {

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/geoip/GeoIpResolverIds.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/geoip/GeoIpResolverIds.java
@@ -1,7 +1,7 @@
 package io.github.mabartos.context.location.geoip;
 
 /**
- * Stable provider ids for HTTP GeoIP backends shipped with the ip-api extension.
+ * Stable provider ids for GeoIP backends shipped with the ip-api extension.
  */
 public final class GeoIpResolverIds {
 
@@ -9,6 +9,7 @@ public final class GeoIpResolverIds {
     public static final String IPAPI_CO_PRO = "ipapi-co-pro";
     public static final String IP_API_COM_FREE = "ip-api-com-free";
     public static final String IP_API_COM_PRO = "ip-api-com-pro";
+    public static final String MAXMIND = "maxmind";
 
     public static final String DEFAULT_FALLBACK = IPAPI_CO_FREE;
 

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindDatabaseDownloader.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindDatabaseDownloader.java
@@ -1,0 +1,206 @@
+package io.github.mabartos.context.location.maxmind;
+
+import com.maxmind.geoip2.DatabaseReader;
+import io.github.mabartos.context.location.geoip.AdaptiveConfig;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * Downloads GeoLite2-City from MaxMind (official API) or a community mirror.
+ */
+public final class MaxMindDatabaseDownloader {
+
+    static final String OFFICIAL_URL =
+            "https://download.maxmind.com/geoip/databases/GeoLite2-City/download?suffix=tar.gz";
+
+    static final String MIRROR_URL =
+            "https://github.com/P3TERX/GeoLite.mmdb/raw/download/GeoLite2-City.mmdb";
+
+    private static final Logger log = Logger.getLogger(MaxMindDatabaseDownloader.class);
+
+    private final HttpClient httpClient;
+
+    public MaxMindDatabaseDownloader() {
+        this(HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(30)).followRedirects(HttpClient.Redirect.NORMAL)
+                .build());
+    }
+
+    MaxMindDatabaseDownloader(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Resolves the download source from configured credentials.
+     */
+    public MaxMindDownloadSource resolveSource() {
+        if (AdaptiveConfig.maxMindOfficialCredentialsPresent()) {
+            return MaxMindDownloadSource.OFFICIAL;
+        }
+        if (AdaptiveConfig.maxMindPartialCredentialsPresent()) {
+            log.warnf(
+                    "Both %s and %s must be set for official MaxMind downloads; "
+                            + "falling back to community mirror (POC/dev only).",
+                    AdaptiveConfig.MAXMIND_ACCOUNT_ID_PROPERTY,
+                    AdaptiveConfig.MAXMIND_LICENSE_KEY_PROPERTY);
+        } else {
+            log.warn(
+                    "MaxMind credentials not configured; downloading GeoLite2-City from community mirror "
+                            + "(POC/dev only — use official credentials in production per GeoLite2 EULA).");
+        }
+        return MaxMindDownloadSource.MIRROR;
+    }
+
+    /**
+     * Downloads the database to {@code targetPath} (parent directories are created).
+     *
+     * @return {@code true} when a valid database file was written
+     */
+    public boolean download(Path targetPath, MaxMindDownloadSource source) {
+        Path parent = targetPath.getParent();
+        if (parent != null) {
+            try {
+                Files.createDirectories(parent);
+            } catch (IOException e) {
+                log.errorf(e, "Failed to create MaxMind database directory %s", parent);
+                return false;
+            }
+        }
+
+        Path tmpPath = Path.of(targetPath.toString() + ".tmp");
+        try {
+            if (source == MaxMindDownloadSource.OFFICIAL) {
+                downloadOfficial(tmpPath);
+            } else {
+                downloadMirror(tmpPath);
+            }
+            if (!validateDatabase(tmpPath)) {
+                Files.deleteIfExists(tmpPath);
+                return false;
+            }
+            Files.move(tmpPath, targetPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            log.debugf(
+                    "MaxMind GeoLite2-City database updated from %s (%s bytes) at %s",
+                    source,
+                    Files.size(targetPath),
+                    targetPath);
+            return true;
+        } catch (IOException | InterruptedException e) {
+            log.errorf(e, "MaxMind database download failed (source=%s)", source);
+            return false;
+        } finally {
+            try {
+                Files.deleteIfExists(tmpPath);
+            } catch (IOException e) {
+                log.warnf(e, "Failed to delete temporary MaxMind database %s", tmpPath);
+            }
+            if (Thread.currentThread().isInterrupted()) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private void downloadOfficial(Path targetPath) throws IOException, InterruptedException {
+        String accountId = AdaptiveConfig.maxMindAccountId().orElseThrow();
+        String licenseKey = AdaptiveConfig.maxMindLicenseKey().orElseThrow();
+        String basicAuth = Base64.getEncoder()
+                .encodeToString((accountId + ":" + licenseKey).getBytes(StandardCharsets.UTF_8));
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(OFFICIAL_URL))
+                .timeout(Duration.ofMinutes(5))
+                .header("Authorization", "Basic " + basicAuth)
+                .GET()
+                .build();
+
+        HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        int status = response.statusCode();
+        if (status != 200) {
+            response.body().close();
+            throw new IOException("MaxMind official download returned HTTP " + status);
+        }
+
+        try (InputStream body = response.body()) {
+            extractMmdbFromTarGz(body, targetPath);
+        }
+    }
+
+    private void downloadMirror(Path targetPath) throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(MIRROR_URL))
+                .timeout(Duration.ofMinutes(5))
+                .GET()
+                .build();
+
+        HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+        int status = response.statusCode();
+        if (status != 200) {
+            response.body().close();
+            throw new IOException("MaxMind mirror download returned HTTP " + status);
+        }
+
+        try (InputStream body = response.body()) {
+            Files.copy(body, targetPath, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    static void extractMmdbFromTarGz(InputStream gzipStream, Path targetPath) throws IOException {
+        try (GZIPInputStream gzip = new GZIPInputStream(gzipStream);
+                TarArchiveInputStream tar = new TarArchiveInputStream(gzip)) {
+            TarArchiveEntry entry;
+            while ((entry = tar.getNextEntry()) != null) {
+                if (entry.isDirectory()) {
+                    continue;
+                }
+                if (entry.getName().endsWith("GeoLite2-City.mmdb")) {
+                    Files.copy(tar, targetPath, StandardCopyOption.REPLACE_EXISTING);
+                    return;
+                }
+            }
+        }
+        throw new IOException("GeoLite2-City.mmdb not found in MaxMind archive");
+    }
+
+    static boolean validateDatabase(Path databasePath) {
+        try {
+            if (!Files.isRegularFile(databasePath) || Files.size(databasePath) == 0) {
+                log.warnf("MaxMind database validation failed: empty or missing file at %s", databasePath);
+                return false;
+            }
+            try (DatabaseReader reader = new DatabaseReader.Builder(databasePath.toFile()).build()) {
+                reader.metadata();
+                return true;
+            }
+        } catch (IOException e) {
+            log.warnf(e, "MaxMind database validation failed for %s", databasePath);
+            return false;
+        }
+    }
+
+    static Optional<Long> fileAgeMillis(Path path) {
+        try {
+            if (!Files.isRegularFile(path)) {
+                return Optional.empty();
+            }
+            long modified = Files.getLastModifiedTime(path).toMillis();
+            return Optional.of(Math.max(0L, System.currentTimeMillis() - modified));
+        } catch (IOException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindDatabaseManager.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindDatabaseManager.java
@@ -1,0 +1,173 @@
+package io.github.mabartos.context.location.maxmind;
+
+import com.maxmind.db.CHMCache;
+import com.maxmind.geoip2.DatabaseReader;
+import io.github.mabartos.context.location.geoip.AdaptiveConfig;
+import io.github.mabartos.context.location.geoip.GeoIpResolverChain;
+import io.github.mabartos.context.location.geoip.GeoIpResolverIds;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * JVM-wide GeoLite2-City lifecycle: download, periodic refresh, and thread-safe {@link DatabaseReader} access.
+ */
+public final class MaxMindDatabaseManager {
+
+    private static final Logger log = Logger.getLogger(MaxMindDatabaseManager.class);
+
+    private static final MaxMindDatabaseManager INSTANCE = new MaxMindDatabaseManager();
+
+    /** Grace period before closing a replaced reader so in-flight lookups can finish. */
+    private static final Duration READER_CLOSE_DELAY = Duration.ofMinutes(1);
+
+    final AtomicReference<DatabaseReader> readerRef = new AtomicReference<>();
+    private final Set<DatabaseReader> retiredReaders = ConcurrentHashMap.newKeySet();
+    private final MaxMindDatabaseDownloader downloader = new MaxMindDatabaseDownloader();
+
+    volatile Path dbPath;
+    volatile Duration refreshInterval;
+    private volatile ScheduledExecutorService scheduler;
+
+    private MaxMindDatabaseManager() {
+    }
+
+    public static MaxMindDatabaseManager getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Starts the manager when {@code maxmind} is listed in location providers.
+     */
+    public synchronized void startIfEnabled() {
+        if (!isMaxMindConfigured()) {
+            log.debug("MaxMind GeoIP resolver not configured; skipping database manager startup.");
+            return;
+        }
+        if (scheduler != null) {
+            return;
+        }
+
+        dbPath = AdaptiveConfig.maxMindDbPath();
+        refreshInterval = AdaptiveConfig.maxMindDbRefreshInterval();
+        scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread thread = new Thread(r, "maxmind-geolite2-refresh");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+        refreshIfStale();
+        long intervalMs = refreshInterval.toMillis();
+        scheduler.scheduleWithFixedDelay(this::refreshIfStale, intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+        log.infof(
+                "MaxMind database manager started (path=%s, refreshInterval=%s)",
+                dbPath,
+                refreshInterval);
+    }
+
+    public synchronized void shutdown() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+            scheduler = null;
+        }
+        closeReader(readerRef.getAndSet(null));
+        for (DatabaseReader retired : retiredReaders) {
+            closeReader(retired);
+        }
+        retiredReaders.clear();
+    }
+
+    public Optional<DatabaseReader> getReader() {
+        return Optional.ofNullable(readerRef.get());
+    }
+
+    void refreshIfStale() {
+        if (dbPath == null) {
+            dbPath = AdaptiveConfig.maxMindDbPath();
+        }
+        if (refreshInterval == null) {
+            refreshInterval = AdaptiveConfig.maxMindDbRefreshInterval();
+        }
+
+        boolean missing = !Files.isRegularFile(dbPath);
+        boolean stale = MaxMindDatabaseDownloader.fileAgeMillis(dbPath)
+                .map(age -> age > refreshInterval.toMillis())
+                .orElse(true);
+
+        if (missing || stale) {
+            refresh();
+        } else if (readerRef.get() == null) {
+            openReader(dbPath);
+        }
+    }
+
+    void refresh() {
+        MaxMindDownloadSource source = downloader.resolveSource();
+        log.debugf("Refreshing MaxMind GeoLite2-City database (source=%s, path=%s)", source, dbPath);
+        if (downloader.download(dbPath, source)) {
+            openReader(dbPath);
+        } else if (readerRef.get() == null && Files.isRegularFile(dbPath)) {
+            log.warn("MaxMind download failed; attempting to use existing database file.");
+            openReader(dbPath);
+        }
+    }
+
+    void openReader(Path path) {
+        if (!Files.isRegularFile(path)) {
+            return;
+        }
+        try {
+            DatabaseReader newReader = new DatabaseReader.Builder(path.toFile())
+                    .withCache(new CHMCache())
+                    .build();
+            DatabaseReader previous = readerRef.getAndSet(newReader);
+            deferClose(previous);
+            log.debugf("MaxMind DatabaseReader opened for %s", path);
+        } catch (IOException e) {
+            log.errorf(e, "Failed to open MaxMind database at %s", path);
+        }
+    }
+
+    private void deferClose(DatabaseReader reader) {
+        if (reader == null) {
+            return;
+        }
+        retiredReaders.add(reader);
+        ScheduledExecutorService executor = scheduler;
+        if (executor == null || executor.isShutdown()) {
+            closeRetired(reader);
+            return;
+        }
+        executor.schedule(() -> closeRetired(reader), READER_CLOSE_DELAY.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    private void closeRetired(DatabaseReader reader) {
+        if (reader != null && retiredReaders.remove(reader)) {
+            closeReader(reader);
+        }
+    }
+
+    private static void closeReader(DatabaseReader reader) {
+        if (reader != null) {
+            try {
+                reader.close();
+            } catch (IOException e) {
+                log.warn("Failed to close MaxMind DatabaseReader", e);
+            }
+        }
+    }
+
+    private static boolean isMaxMindConfigured() {
+        return GeoIpResolverChain.isProviderConfigured(GeoIpResolverIds.MAXMIND);
+    }
+}

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindDownloadSource.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindDownloadSource.java
@@ -1,0 +1,11 @@
+package io.github.mabartos.context.location.maxmind;
+
+/**
+ * Download source for the GeoLite2-City database.
+ */
+public enum MaxMindDownloadSource {
+    /** MaxMind official HTTPS API (requires account id and license key). */
+    OFFICIAL,
+    /** Community mirror for quick POC (not for production; see GeoLite2 EULA). */
+    MIRROR
+}

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindGeoIpResolver.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindGeoIpResolver.java
@@ -1,0 +1,57 @@
+package io.github.mabartos.context.location.maxmind;
+
+import com.maxmind.geoip2.DatabaseReader;
+import com.maxmind.geoip2.exception.GeoIp2Exception;
+import io.github.mabartos.context.ip.IPAddress;
+import io.github.mabartos.context.location.LocationData;
+import io.github.mabartos.context.location.geoip.GeoIpResolver;
+import io.github.mabartos.context.location.geoip.GeoIpResolverIds;
+import jakarta.annotation.Nonnull;
+import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Optional;
+
+/**
+ * GeoIP via local MaxMind GeoLite2-City database ({@value GeoIpResolverIds#MAXMIND}).
+ */
+public final class MaxMindGeoIpResolver implements GeoIpResolver {
+
+    private static final Logger log = Logger.getLogger(MaxMindGeoIpResolver.class);
+
+    private final MaxMindDatabaseManager databaseManager;
+
+    public MaxMindGeoIpResolver() {
+        this(MaxMindDatabaseManager.getInstance());
+    }
+
+    MaxMindGeoIpResolver(MaxMindDatabaseManager databaseManager) {
+        this.databaseManager = databaseManager;
+    }
+
+    @Override
+    @Nonnull
+    public String id() {
+        return GeoIpResolverIds.MAXMIND;
+    }
+
+    @Override
+    public Optional<LocationData> resolve(KeycloakSession session, RealmModel realm, IPAddress ip) {
+        Optional<DatabaseReader> reader = databaseManager.getReader();
+        if (reader.isEmpty()) {
+            log.trace("MaxMind DatabaseReader not available; skipping lookup.");
+            return Optional.empty();
+        }
+
+        try {
+            InetAddress address = InetAddress.getByName(ip.toString());
+            return reader.get().tryCity(address).flatMap(MaxMindLocationData::from);
+        } catch (IOException | GeoIp2Exception e) {
+            log.warnf(e, "MaxMind lookup failed for %s", ip);
+            return Optional.empty();
+        }
+    }
+}

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindGeoIpResolverFactory.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindGeoIpResolverFactory.java
@@ -1,0 +1,33 @@
+package io.github.mabartos.context.location.maxmind;
+
+import io.github.mabartos.context.location.geoip.GeoIpResolver;
+import io.github.mabartos.context.location.geoip.GeoIpResolverFactory;
+import io.github.mabartos.context.location.geoip.GeoIpResolverIds;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+
+/**
+ * Factory for the local MaxMind GeoLite2-City resolver ({@value GeoIpResolverIds#MAXMIND}).
+ */
+public final class MaxMindGeoIpResolverFactory implements GeoIpResolverFactory {
+
+    @Override
+    public GeoIpResolver create(KeycloakSession session) {
+        return new MaxMindGeoIpResolver();
+    }
+
+    @Override
+    public String getId() {
+        return GeoIpResolverIds.MAXMIND;
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        MaxMindDatabaseManager.getInstance().startIfEnabled();
+    }
+
+    @Override
+    public void close() {
+        MaxMindDatabaseManager.getInstance().shutdown();
+    }
+}

--- a/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindLocationData.java
+++ b/extensions/ip-api/src/main/java/io/github/mabartos/context/location/maxmind/MaxMindLocationData.java
@@ -1,0 +1,110 @@
+package io.github.mabartos.context.location.maxmind;
+
+import com.maxmind.geoip2.model.CityResponse;
+import io.github.mabartos.context.location.LocationData;
+import org.keycloak.utils.StringUtil;
+
+import java.util.Optional;
+
+/**
+ * Maps a MaxMind {@link CityResponse} to {@link LocationData}.
+ */
+final class MaxMindLocationData implements LocationData {
+
+    private final String city;
+    private final String region;
+    private final String regionCode;
+    private final String country;
+    private final String continent;
+    private final String postalCode;
+    private final Double latitude;
+    private final Double longitude;
+    private final String timezone;
+
+    private MaxMindLocationData(CityResponse response) {
+        this.city = nullToNull(response.city() != null ? response.city().name() : null);
+        this.region = nullToNull(response.mostSpecificSubdivision() != null
+                ? response.mostSpecificSubdivision().name()
+                : null);
+        this.regionCode = nullToNull(response.mostSpecificSubdivision() != null
+                ? response.mostSpecificSubdivision().isoCode()
+                : null);
+        this.country = nullToNull(response.country() != null ? response.country().name() : null);
+        this.continent = nullToNull(response.continent() != null ? response.continent().code() : null);
+        this.postalCode = nullToNull(response.postal() != null ? response.postal().code() : null);
+        if (response.location() != null) {
+            this.latitude = response.location().latitude();
+            this.longitude = response.location().longitude();
+            this.timezone = nullToNull(response.location().timeZone());
+        } else {
+            this.latitude = null;
+            this.longitude = null;
+            this.timezone = null;
+        }
+    }
+
+    static Optional<LocationData> from(CityResponse response) {
+        if (response == null) {
+            return Optional.empty();
+        }
+        String countryName = response.country() != null ? response.country().name() : null;
+        if (!StringUtil.isNotBlank(countryName)) {
+            return Optional.empty();
+        }
+        return Optional.of(new MaxMindLocationData(response));
+    }
+
+    private static String nullToNull(String value) {
+        return value != null && !value.isBlank() ? value : null;
+    }
+
+    @Override
+    public String getCity() {
+        return city;
+    }
+
+    @Override
+    public String getRegion() {
+        return region;
+    }
+
+    @Override
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    @Override
+    public String getCountry() {
+        return country;
+    }
+
+    @Override
+    public String getContinent() {
+        return continent;
+    }
+
+    @Override
+    public String getPostalCode() {
+        return postalCode;
+    }
+
+    @Override
+    public Double getLatitude() {
+        return latitude;
+    }
+
+    @Override
+    public Double getLongitude() {
+        return longitude;
+    }
+
+    @Override
+    public String getTimezone() {
+        return timezone;
+    }
+
+    @Override
+    public String getCurrency() {
+        return null;
+    }
+}

--- a/extensions/ip-api/src/main/resources/META-INF/services/io.github.mabartos.context.location.geoip.GeoIpResolverFactory
+++ b/extensions/ip-api/src/main/resources/META-INF/services/io.github.mabartos.context.location.geoip.GeoIpResolverFactory
@@ -2,3 +2,4 @@ io.github.mabartos.context.location.IpApiCoGeoIpResolverFreeFactory
 io.github.mabartos.context.location.IpApiCoGeoIpResolverProFactory
 io.github.mabartos.context.location.IpApiComGeoIpResolverFreeFactory
 io.github.mabartos.context.location.IpApiComGeoIpResolverProFactory
+io.github.mabartos.context.location.maxmind.MaxMindGeoIpResolverFactory

--- a/extensions/ip-api/src/test/java/io/github/mabartos/context/location/geoip/GeoIpResolverChainTest.java
+++ b/extensions/ip-api/src/test/java/io/github/mabartos/context/location/geoip/GeoIpResolverChainTest.java
@@ -65,6 +65,7 @@ class GeoIpResolverChainTest {
     void hasCredentialsFor_freeProvidersDoNotRequireSecrets() {
         assertThat(GeoIpResolverChain.hasCredentialsFor(GeoIpResolverIds.IPAPI_CO_FREE), is(true));
         assertThat(GeoIpResolverChain.hasCredentialsFor(GeoIpResolverIds.IP_API_COM_FREE), is(true));
+        assertThat(GeoIpResolverChain.hasCredentialsFor(GeoIpResolverIds.MAXMIND), is(true));
     }
 
     @Test
@@ -157,6 +158,12 @@ class GeoIpResolverChainTest {
         assertThat(
                 chain.stream().map(GeoIpResolver::id).toList(),
                 contains(GeoIpResolverIds.IPAPI_CO_FREE, GeoIpResolverIds.IP_API_COM_FREE));
+    }
+
+    @Test
+    void isProviderConfigured_matchesParsedProviderIds() {
+        assertThat(GeoIpResolverChain.isProviderConfigured(GeoIpResolverIds.IPAPI_CO_FREE), is(true));
+        assertThat(GeoIpResolverChain.isProviderConfigured(GeoIpResolverIds.MAXMIND), is(false));
     }
 
     @Test

--- a/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindDatabaseDownloaderTest.java
+++ b/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindDatabaseDownloaderTest.java
@@ -1,0 +1,57 @@
+package io.github.mabartos.context.location.maxmind;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MaxMindDatabaseDownloaderTest {
+
+    @Test
+    void resolveSource_defaultsToMirrorWithoutCredentials() {
+        assertThat(new MaxMindDatabaseDownloader().resolveSource(), is(MaxMindDownloadSource.MIRROR));
+    }
+
+    @Test
+    void extractMmdbFromTarGz_writesMmdbEntry(@TempDir Path tempDir) throws IOException {
+        MaxMindTestFixtures.assumeTestDatabasePresent();
+        Path testDb = MaxMindTestFixtures.testDatabasePath();
+        Path tarGz = createTarGzFixture(testDb);
+        Path target = tempDir.resolve("GeoLite2-City.mmdb");
+
+        try (var input = Files.newInputStream(tarGz)) {
+            MaxMindDatabaseDownloader.extractMmdbFromTarGz(input, target);
+        }
+
+        assertThat(MaxMindDatabaseDownloader.validateDatabase(target), is(true));
+    }
+
+    @Test
+    void validateDatabase_rejectsMissingFile(@TempDir Path tempDir) {
+        assertThat(MaxMindDatabaseDownloader.validateDatabase(tempDir.resolve("missing.mmdb")), is(false));
+    }
+
+    private static Path createTarGzFixture(Path mmdbSource) throws IOException {
+        Path tarGz = Files.createTempFile("geolite2-city", ".tar.gz");
+        byte[] content = Files.readAllBytes(mmdbSource);
+        try (OutputStream fileOut = Files.newOutputStream(tarGz);
+                GZIPOutputStream gzipOut = new GZIPOutputStream(fileOut);
+                TarArchiveOutputStream tarOut = new TarArchiveOutputStream(gzipOut)) {
+            TarArchiveEntry entry = new TarArchiveEntry("GeoLite2-City_20260101/GeoLite2-City.mmdb");
+            entry.setSize(content.length);
+            tarOut.putArchiveEntry(entry);
+            tarOut.write(content);
+            tarOut.closeArchiveEntry();
+        }
+        return tarGz;
+    }
+}

--- a/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindDatabaseManagerTest.java
+++ b/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindDatabaseManagerTest.java
@@ -1,0 +1,56 @@
+package io.github.mabartos.context.location.maxmind;
+
+import com.maxmind.db.CHMCache;
+import com.maxmind.geoip2.DatabaseReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MaxMindDatabaseManagerTest {
+
+    @AfterEach
+    void tearDown() {
+        MaxMindDatabaseManager.getInstance().shutdown();
+    }
+
+    @Test
+    void openReader_loadsExistingDatabase(@TempDir Path tempDir) throws Exception {
+        MaxMindTestFixtures.assumeTestDatabasePresent();
+        Path testDb = MaxMindTestFixtures.testDatabasePath();
+        Path dbPath = tempDir.resolve("GeoLite2-City.mmdb");
+        Files.copy(testDb, dbPath, StandardCopyOption.REPLACE_EXISTING);
+
+        MaxMindDatabaseManager manager = MaxMindDatabaseManager.getInstance();
+        manager.dbPath = dbPath;
+        manager.refreshInterval = Duration.ofDays(7);
+        manager.openReader(dbPath);
+
+        assertThat(manager.getReader().isPresent(), is(true));
+    }
+
+    @Test
+    void refreshIfStale_skipsDownloadWhenDatabaseIsFresh(@TempDir Path tempDir) throws Exception {
+        MaxMindTestFixtures.assumeTestDatabasePresent();
+        Path testDb = MaxMindTestFixtures.testDatabasePath();
+        Path dbPath = tempDir.resolve("GeoLite2-City.mmdb");
+        Files.copy(testDb, dbPath, StandardCopyOption.REPLACE_EXISTING);
+
+        MaxMindDatabaseManager manager = MaxMindDatabaseManager.getInstance();
+        manager.dbPath = dbPath;
+        manager.refreshInterval = Duration.ofDays(7);
+        manager.readerRef.set(new DatabaseReader.Builder(dbPath.toFile()).withCache(new CHMCache()).build());
+
+        manager.refreshIfStale();
+
+        assertThat(manager.getReader().isPresent(), is(true));
+        assertThat(Files.size(dbPath), is(Files.size(testDb)));
+    }
+}

--- a/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindGeoIpResolverTest.java
+++ b/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindGeoIpResolverTest.java
@@ -1,0 +1,53 @@
+package io.github.mabartos.context.location.maxmind;
+
+import io.github.mabartos.context.ip.IPAddress;
+import io.github.mabartos.context.location.LocationData;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class MaxMindGeoIpResolverTest {
+
+    @AfterEach
+    void tearDown() {
+        MaxMindDatabaseManager.getInstance().shutdown();
+    }
+
+    @Test
+    void resolve_returnsLocationForKnownIp() throws Exception {
+        MaxMindTestFixtures.assumeTestDatabasePresent();
+        Path testDb = MaxMindTestFixtures.testDatabasePath();
+        Path dbPath = Files.createTempFile("geolite2-city", ".mmdb");
+        dbPath.toFile().deleteOnExit();
+        Files.copy(testDb, dbPath, StandardCopyOption.REPLACE_EXISTING);
+
+        MaxMindDatabaseManager manager = MaxMindDatabaseManager.getInstance();
+        manager.dbPath = dbPath;
+        manager.openReader(dbPath);
+
+        MaxMindGeoIpResolver resolver = new MaxMindGeoIpResolver(manager);
+        IPAddress ip = IPAddress.parse("81.2.69.160");
+
+        Optional<LocationData> data = resolver.resolve(null, null, ip);
+
+        assertThat(data.isPresent(), is(true));
+        assertThat(data.get().getCountry(), is("United Kingdom"));
+        assertThat(data.get().getCity(), is("London"));
+        assertThat(resolver.id(), is("maxmind"));
+    }
+
+    @Test
+    void resolve_returnsEmptyWhenReaderUnavailable() {
+        MaxMindGeoIpResolver resolver = new MaxMindGeoIpResolver(MaxMindDatabaseManager.getInstance());
+        Optional<LocationData> data = resolver.resolve(null, null, IPAddress.parse("8.8.8.8"));
+
+        assertThat(data.isPresent(), is(false));
+    }
+}

--- a/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindLocationDataTest.java
+++ b/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindLocationDataTest.java
@@ -1,0 +1,35 @@
+package io.github.mabartos.context.location.maxmind;
+
+import com.maxmind.geoip2.DatabaseReader;
+import io.github.mabartos.context.location.LocationData;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetAddress;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+class MaxMindLocationDataTest {
+
+    @Test
+    void from_mapsCityResponseToLocationData() throws Exception {
+        MaxMindTestFixtures.assumeTestDatabasePresent();
+
+        try (DatabaseReader reader =
+                new DatabaseReader.Builder(MaxMindTestFixtures.testDatabasePath().toFile()).build()) {
+            var response = reader.city(InetAddress.getByName("81.2.69.160"));
+            LocationData data = MaxMindLocationData.from(response).orElseThrow();
+
+            assertThat(data.getCountry(), is("United Kingdom"));
+            assertThat(data.getCity(), is("London"));
+            assertThat(data.getRegion(), is("England"));
+            assertThat(data.getRegionCode(), is("ENG"));
+            assertThat(data.getContinent(), is("EU"));
+            assertThat(data.getLatitude(), notNullValue());
+            assertThat(data.getLongitude(), notNullValue());
+            assertThat(data.getTimezone(), is("Europe/London"));
+            assertThat(data.getCurrency(), is((String) null));
+        }
+    }
+}

--- a/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindTestFixtures.java
+++ b/extensions/ip-api/src/test/java/io/github/mabartos/context/location/maxmind/MaxMindTestFixtures.java
@@ -1,0 +1,37 @@
+package io.github.mabartos.context.location.maxmind;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Loads the official MaxMind test database downloaded at build time
+ * ({@code generate-test-resources}) into {@code target/test-classes/maxmind/}.
+ */
+final class MaxMindTestFixtures {
+
+    private static final String TEST_DB_RESOURCE = "/maxmind/GeoLite2-City-Test.mmdb";
+
+    private MaxMindTestFixtures() {
+    }
+
+    static Path testDatabasePath() throws IOException {
+        var resource = MaxMindTestFixtures.class.getResource(TEST_DB_RESOURCE);
+        if (resource == null) {
+            throw new org.opentest4j.TestAbortedException(
+                    "GeoLite2-City-Test.mmdb not on classpath; run mvn test (downloads from MaxMind-DB)");
+        }
+        try {
+            return Path.of(resource.toURI());
+        } catch (URISyntaxException e) {
+            throw new IOException("Invalid test database URI", e);
+        }
+    }
+
+    static void assumeTestDatabasePresent() throws IOException {
+        if (!Files.isRegularFile(testDatabasePath())) {
+            throw new org.opentest4j.TestAbortedException("Test database missing at " + TEST_DB_RESOURCE);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `maxmind` GeoIP resolver to the `ip-api` extension.

- Local lookups via [GeoIP2 Java](https://github.com/maxmind/GeoIP2-java) (`GeoLite2-City.mmdb`), no per-request HTTP call.
- Automatic database lifecycle : download on startup when missing or stale, periodic refresh (configurable, 7 days by default).
- Two download sources:
  - Official when both `KC_ADAPTIVE_MAXMIND_ACCOUNT_ID` and `KC_ADAPTIVE_MAXMIND_LICENSE_KEY` are set (MaxMind HTTPS API, `tar.gz` extraction).
  - Community mirror ([P3TERX/GeoLite.mmdb](https://github.com/P3TERX/GeoLite.mmdb)) when credentials are absent. Intended for quick POC/dev only, production should use official credentials per the GeoLite2 EULA.
- Runtime configuration through existing `KC_ADAPTIVE_*` env vars.
- Shaded dependencies (`geoip2`, `maxmind-db`, `commons-compress`) bundled in the extension JAR for Keycloak `providers/`.

Relates to #33 and extends the multi-backend GeoIP work from #43.

## Configuration

| Environment variable | Description | Default |
|---|---|---|
| `KC_ADAPTIVE_LOCATION_PROVIDERS` | Include `maxmind` in the resolver chain | `ipapi-co-free` |
| `KC_ADAPTIVE_MAXMIND_ACCOUNT_ID` | MaxMind account ID | _(none)_ |
| `KC_ADAPTIVE_MAXMIND_LICENSE_KEY` | MaxMind license key | _(none)_ |
| `KC_ADAPTIVE_MAXMIND_DB_REFRESH_INTERVAL` | ISO-8601 refresh interval | `PT7D` |
| `KC_ADAPTIVE_MAXMIND_DB_PATH` | Local `.mmdb` path | `{kc.data-dir}/adaptive-authn/geolite2/GeoLite2-City.mmdb` |

Examples

```shell
# Production (official MaxMind download)
KC_ADAPTIVE_LOCATION_PROVIDERS=maxmind
KC_ADAPTIVE_MAXMIND_ACCOUNT_ID=123456
KC_ADAPTIVE_MAXMIND_LICENSE_KEY=your_license_key

# POC without MaxMind account (mirror)
KC_ADAPTIVE_LOCATION_PROVIDERS=maxmind

# Fallback chain
KC_ADAPTIVE_LOCATION_PROVIDERS=maxmind,ipapi-co-free
```