### PR TITLE
ci: build extensions in CI and include them in release assets

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: Build Keycloak Adaptive Authentication extension
+name: Build Keycloak Adaptive Authentication
 
 on:
   push:
@@ -21,7 +21,7 @@ jobs:
             test-args: -Dkeycloak.version=26.7.0
           - keycloak-version: 26.6.4
             build-args: -Pdist-maven -Dkeycloak.version=26.6.4 -Dkeycloak.test.realm.source=legacy -Dssf.skip
-            test-args: -Dkeycloak.version=26.6.4 -Dkeycloak.test.realm.source=legacy
+            test-args: -Dkeycloak.version=26.6.4 -Dkeycloak.test.realm.source=legacy -Dssf.skip
 
     name: Keycloak ${{ matrix.keycloak-version }}
     steps:
@@ -34,15 +34,32 @@ jobs:
         distribution: 'temurin'
         cache: maven
 
-    - name: Build extension
+    - name: Build core and extensions
       # maven.test.skip (not skipTests): tests compile later with test-args (version may differ from build)
       run: ./mvnw clean install -Dmaven.test.skip=true -Pbuild-distribution ${{ matrix.build-args }}
+
+    - name: Verify extension artifacts
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        jars=(extensions/*/target/keycloak-adaptive-ext-*.jar)
+        if [ "${#jars[@]}" -eq 0 ]; then
+          echo "No extension JARs found under extensions/*/target/"
+          exit 1
+        fi
+        printf '%s\n' "${jars[@]}"
+
+    - name: Copy extensions to distribution
+      run: ./mvnw -f core exec:exec@copy-extensions ${{ matrix.test-args }}
 
     - name: Test execute 'build' command
       run: ./mvnw -f core exec:exec@build ${{ matrix.test-args }}
 
-    - name: Unit tests
+    - name: Unit tests (core)
       run: ./mvnw -f core test ${{ matrix.test-args }}
+
+    - name: Unit tests (extensions)
+      run: ./mvnw -f extensions test ${{ matrix.test-args }}
 
     - name: Integration tests
       run: ./mvnw -f tests test ${{ matrix.test-args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,19 @@ jobs:
       - name: Set release version
         run: ./set-version.sh "${VERSION}"
 
+      - name: Build core and extensions
+        run: |
+          # -pl '!tests': full reactor except IT module; includes core and all extension submodules.
+          # -pl extensions -am only installs aggregator POMs, not ip-api/openrouter/ssf jars.
+          # build-distribution profile lives in core/pom.xml and requires core in the reactor.
+          ./mvnw -B -ntp -U clean install -pl '!tests' \
+            -Dmaven.test.skip=true \
+            -Pbuild-distribution
+
       - name: Deploy to GitHub Packages
         run: |
           echo "Publishing to https://maven.pkg.github.com/${GITHUB_REPOSITORY}"
-          ./mvnw -B -ntp -U clean deploy -pl core -am \
+          ./mvnw -B -ntp deploy -pl core \
             -Dmaven.test.skip=true \
             -Dgithub.packages.repository="${GITHUB_REPOSITORY}"
 
@@ -80,6 +89,13 @@ jobs:
           cp "${CORE_JAR}" dist/
           cp "${THEME_JAR}" dist/adaptive-authn-theme-${VERSION}.jar
           cp "${REALM_JSON}" dist/adaptive-realm-${VERSION}.json
+          shopt -s nullglob
+          ext_jars=(extensions/*/target/keycloak-adaptive-ext-*.jar)
+          if [ "${#ext_jars[@]}" -eq 0 ]; then
+            echo "No extension JARs found under extensions/*/target/"
+            exit 1
+          fi
+          cp "${ext_jars[@]}" dist/
           (cd dist && for f in *.jar *.json; do sha256sum "${f}" > "${f}.sha256"; done)
           ls -la dist/
           (cd dist && cat *.sha256)
@@ -124,6 +140,13 @@ jobs:
           test -f dist/adaptive-authn-theme-${VERSION}.jar
           test -f dist/adaptive-realm-${VERSION}.json
           test -f dist/keycloak-adaptive-authn-${VERSION}.jar
+          shopt -s nullglob
+          ext_jars=(dist/keycloak-adaptive-ext-*.jar)
+          if [ "${#ext_jars[@]}" -eq 0 ]; then
+            echo "No extension JARs found in dist/"
+            exit 1
+          fi
+          printf '%s\n' "${ext_jars[@]}"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
                                 <arguments>
                                     <argument>-c</argument>
                                     <argument>
-                                        cp extensions/*/target/*.jar ${keycloak.exec.distribution.path}/providers/
+                                        cp ${maven.multiModuleProjectDirectory}/extensions/*/target/*.jar ${keycloak.exec.distribution.path}/providers/
                                     </argument>
                                 </arguments>
                             </configuration>


### PR DESCRIPTION
Hello @mabartos,

Proposal to extend CI/CD to build and release extension modules alongside core 😉

Tested on my side :
- Release : https://github.com/thomasdelorge/keycloak-adaptive-authn/releases/tag/1.0.12
- Pipeline build & release : https://github.com/thomasdelorge/keycloak-adaptive-authn/actions/runs/29147442267
- Pipeline tests  : https://github.com/thomasdelorge/keycloak-adaptive-authn/actions/runs/29147973733/job/86532656672

Note : I rebased the branch into a single commit before opening this PR. I had temporarily extended the CI trigger to my feature branch (ci/**) to validate the changes on my fork, then removed that before submitting upstream.

Thomas