### PR TITLE
feat(evaluator): realm-configurable scores for core evaluators

### DIFF
--- a/core/src/main/java/io/github/mabartos/context/location/KnownLocationContext.java
+++ b/core/src/main/java/io/github/mabartos/context/location/KnownLocationContext.java
@@ -3,7 +3,6 @@ package io.github.mabartos.context.location;
 import io.github.mabartos.context.UserContexts;
 import io.github.mabartos.spi.context.AbstractUserContext;
 import io.github.mabartos.spi.engine.OnSuccessfulLoginCallback;
-import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import org.jboss.logging.Logger;
@@ -11,7 +10,6 @@ import org.keycloak.common.util.Time;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
-import org.keycloak.utils.StringUtil;
 
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -22,27 +20,11 @@ import java.util.stream.Collectors;
 public class KnownLocationContext extends AbstractUserContext<Set<LocationData>> implements OnSuccessfulLoginCallback {
     private static final Logger logger = Logger.getLogger(KnownLocationContext.class);
     public static final String KNOWN_LOCATIONS_ATTR = "adaptive-location-known";
-    public static final String TTL_DAYS_SETTING_KEY = "ttl-days";
-    public static final String TTL_DAYS_CONFIG = RiskEvaluatorFactory.getAdditionalSettingConfig(
-            "KnownLocationRiskEvaluator", TTL_DAYS_SETTING_KEY);
-    public static final int DEFAULT_TTL_DAYS = 90;
-    // TODO later, it might be configurable
-    private static final int MAX_STORED_LOCATIONS = 10;
+    public static final String TTL_DAYS_CONFIG = KnownLocationSettings.TTL_DAYS_CONFIG;
+    public static final int DEFAULT_TTL_DAYS = KnownLocationSettings.DEFAULT_TTL_DAYS;
 
     public static int getTtlDays(RealmModel realm) {
-        if (realm == null) {
-            return DEFAULT_TTL_DAYS;
-        }
-        var value = realm.getAttribute(TTL_DAYS_CONFIG);
-        if (StringUtil.isBlank(value)) {
-            return DEFAULT_TTL_DAYS;
-        }
-        try {
-            return Integer.parseInt(value);
-        } catch (NumberFormatException e) {
-            logger.warnf("Invalid known location TTL realm attribute '%s', using default %d", value, DEFAULT_TTL_DAYS);
-            return DEFAULT_TTL_DAYS;
-        }
+        return KnownLocationSettings.ttlDays(realm);
     }
 
     public KnownLocationContext(KeycloakSession session) {
@@ -95,10 +77,11 @@ public class KnownLocationContext extends AbstractUserContext<Set<LocationData>>
         removeMatchingLocation(knownLocations, currentKnownLocation);
         knownLocations.add(currentKnownLocation);
 
-        // Keep only the last N locations
-        if (knownLocations.size() > MAX_STORED_LOCATIONS) {
+        // Keep only the last N locations (realm setting)
+        int maxStoredLocations = KnownLocationSettings.maxStoredLocations(realm);
+        if (knownLocations.size() > maxStoredLocations) {
             knownLocations = knownLocations.stream()
-                    .skip(knownLocations.size() - MAX_STORED_LOCATIONS)
+                    .skip(knownLocations.size() - maxStoredLocations)
                     .collect(Collectors.toCollection(LinkedHashSet::new));
         }
 

--- a/core/src/main/java/io/github/mabartos/context/location/KnownLocationSettings.java
+++ b/core/src/main/java/io/github/mabartos/context/location/KnownLocationSettings.java
@@ -1,0 +1,39 @@
+package io.github.mabartos.context.location;
+
+import io.github.mabartos.evaluator.EvaluatorSettingUtils;
+import io.github.mabartos.evaluator.location.KnownLocationRiskEvaluator;
+import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
+import org.keycloak.models.RealmModel;
+
+/**
+ * Realm-configurable persistence settings for {@link KnownLocationContext}.
+ */
+public final class KnownLocationSettings {
+    public static final String TTL_DAYS_SETTING_KEY = "ttl-days";
+    public static final String MAX_STORED_LOCATIONS_SETTING_KEY = "max-stored-locations";
+
+    public static final String TTL_DAYS_CONFIG = RiskEvaluatorFactory.getAdditionalSettingConfig(
+            KnownLocationRiskEvaluator.class, TTL_DAYS_SETTING_KEY);
+    public static final String MAX_STORED_LOCATIONS_CONFIG = RiskEvaluatorFactory.getAdditionalSettingConfig(
+            KnownLocationRiskEvaluator.class, MAX_STORED_LOCATIONS_SETTING_KEY);
+
+    public static final int DEFAULT_TTL_DAYS = 90;
+    public static final int DEFAULT_MAX_STORED_LOCATIONS = 10;
+
+    private KnownLocationSettings() {
+    }
+
+    public static int ttlDays(RealmModel realm) {
+        return EvaluatorSettingUtils.getInt(
+                realm, KnownLocationRiskEvaluator.class, TTL_DAYS_SETTING_KEY, DEFAULT_TTL_DAYS);
+    }
+
+    public static int maxStoredLocations(RealmModel realm) {
+        return EvaluatorSettingUtils.getPositiveInt(
+                realm,
+                KnownLocationRiskEvaluator.class,
+                MAX_STORED_LOCATIONS_SETTING_KEY,
+                1,
+                DEFAULT_MAX_STORED_LOCATIONS);
+    }
+}

--- a/core/src/main/java/io/github/mabartos/evaluator/EvaluatorIntegerConfigProperty.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/EvaluatorIntegerConfigProperty.java
@@ -1,0 +1,21 @@
+package io.github.mabartos.evaluator;
+
+import org.keycloak.provider.ProviderConfigProperty;
+
+/**
+ * Integer evaluator setting with an explicit validation minimum declared at definition time.
+ */
+public final class EvaluatorIntegerConfigProperty extends ProviderConfigProperty {
+
+    private final int minimum;
+
+    public EvaluatorIntegerConfigProperty(
+            String name, String label, String helpText, int defaultValue, int minimum) {
+        super(name, label, helpText, INTEGER_TYPE, defaultValue);
+        this.minimum = minimum;
+    }
+
+    public int getMinimum() {
+        return minimum;
+    }
+}

--- a/core/src/main/java/io/github/mabartos/evaluator/EvaluatorSettingProperties.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/EvaluatorSettingProperties.java
@@ -1,0 +1,74 @@
+package io.github.mabartos.evaluator;
+
+import io.github.mabartos.spi.evaluator.RiskEvaluator;
+import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
+import io.github.mabartos.spi.level.Risk;
+import org.keycloak.provider.ProviderConfigProperty;
+import org.keycloak.provider.ProviderConfigurationBuilder;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Builders for {@link ProviderConfigProperty} entries declared in
+ * {@link RiskEvaluatorFactory#getAdditionalAdminConfigProperties()}.
+ */
+public final class EvaluatorSettingProperties {
+
+    private EvaluatorSettingProperties() {
+    }
+
+    public static List<ProviderConfigProperty> of(ProviderConfigProperty... properties) {
+        return Arrays.asList(properties);
+    }
+
+    public static ProviderConfigProperty scoreProperty(
+            Class<? extends RiskEvaluator> evaluatorClass,
+            String settingKey,
+            String label,
+            String helpText,
+            Risk.Score defaultValue) {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name(RiskEvaluatorFactory.getAdditionalSettingConfig(evaluatorClass, settingKey))
+                .label(label)
+                .helpText(helpText)
+                .type(ProviderConfigProperty.LIST_TYPE)
+                .options(EvaluatorSettingUtils.configurableScoreNames())
+                .defaultValue(defaultValue.name())
+                .add()
+                .build()
+                .getFirst();
+    }
+
+    public static ProviderConfigProperty intProperty(
+            Class<? extends RiskEvaluator> evaluatorClass,
+            String settingKey,
+            String label,
+            String helpText,
+            int defaultValue,
+            int minimum) {
+        return new EvaluatorIntegerConfigProperty(
+                RiskEvaluatorFactory.getAdditionalSettingConfig(evaluatorClass, settingKey),
+                label,
+                helpText,
+                defaultValue,
+                minimum);
+    }
+
+    public static ProviderConfigProperty stringProperty(
+            Class<? extends RiskEvaluator> evaluatorClass,
+            String settingKey,
+            String label,
+            String helpText) {
+        return ProviderConfigurationBuilder.create()
+                .property()
+                .name(RiskEvaluatorFactory.getAdditionalSettingConfig(evaluatorClass, settingKey))
+                .label(label)
+                .helpText(helpText)
+                .type(ProviderConfigProperty.STRING_TYPE)
+                .add()
+                .build()
+                .getFirst();
+    }
+}

--- a/core/src/main/java/io/github/mabartos/evaluator/EvaluatorSettingUtils.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/EvaluatorSettingUtils.java
@@ -1,0 +1,106 @@
+package io.github.mabartos.evaluator;
+
+import io.github.mabartos.spi.evaluator.RiskEvaluator;
+import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
+import io.github.mabartos.spi.level.Risk;
+import org.jboss.logging.Logger;
+import org.keycloak.models.RealmModel;
+import org.keycloak.utils.StringUtil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Shared runtime reads for evaluator settings stored as realm attributes.
+ * Attribute keys follow {@link RiskEvaluatorFactory#getAdditionalSettingConfig(Class, String)}.
+ */
+public final class EvaluatorSettingUtils {
+    private static final Logger logger = Logger.getLogger(EvaluatorSettingUtils.class);
+
+    private EvaluatorSettingUtils() {
+    }
+
+    public static List<String> configurableScoreNames() {
+        return Arrays.stream(Risk.Score.values())
+                .filter(score -> score != Risk.Score.INVALID)
+                .map(Enum::name)
+                .collect(Collectors.toList());
+    }
+
+    public static boolean isValidScoreName(String value) {
+        if (StringUtil.isBlank(value)) {
+            return false;
+        }
+        try {
+            var score = Risk.Score.valueOf(value.trim().toUpperCase());
+            return score != Risk.Score.INVALID;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public static Risk.Score getScore(
+            RealmModel realm,
+            Class<? extends RiskEvaluator> evaluatorClass,
+            String settingKey,
+            Risk.Score defaultValue) {
+        return Optional.ofNullable(realm)
+                .map(r -> r.getAttribute(RiskEvaluatorFactory.getAdditionalSettingConfig(evaluatorClass, settingKey)))
+                .filter(StringUtil::isNotBlank)
+                .map(value -> {
+                    var score = parseScore(value);
+                    return score != null ? score : defaultValue;
+                })
+                .orElse(defaultValue);
+    }
+
+    public static int getInt(
+            RealmModel realm,
+            Class<? extends RiskEvaluator> evaluatorClass,
+            String settingKey,
+            int defaultValue) {
+        return getPositiveInt(realm, evaluatorClass, settingKey, 0, defaultValue);
+    }
+
+    public static int getPositiveInt(
+            RealmModel realm,
+            Class<? extends RiskEvaluator> evaluatorClass,
+            String settingKey,
+            int minimum,
+            int defaultValue) {
+        var configKey = RiskEvaluatorFactory.getAdditionalSettingConfig(evaluatorClass, settingKey);
+        return Optional.ofNullable(realm)
+                .map(r -> r.getAttribute(configKey))
+                .filter(StringUtil::isNotBlank)
+                .flatMap(value -> parseIntAtLeast(value, minimum, configKey, defaultValue))
+                .orElse(defaultValue);
+    }
+
+    private static Risk.Score parseScore(String value) {
+        try {
+            var score = Risk.Score.valueOf(value.trim().toUpperCase());
+            return score == Risk.Score.INVALID ? null : score;
+        } catch (IllegalArgumentException e) {
+            logger.tracef("Invalid risk score config value '%s', using default", value);
+            return null;
+        }
+    }
+
+    private static Optional<Integer> parseIntAtLeast(String value, int minimum, String configKey, int defaultValue) {
+        try {
+            var parsed = Integer.parseInt(value.trim());
+            if (parsed < minimum) {
+                logger.warnf(
+                        "Invalid realm attribute '%s' value '%s' below minimum %d, using default %d",
+                        configKey, value, minimum, defaultValue);
+                return Optional.empty();
+            }
+            return Optional.of(parsed);
+        } catch (NumberFormatException e) {
+            logger.warnf("Invalid realm attribute '%s' value '%s', using default %d", configKey, value, defaultValue);
+            return Optional.empty();
+        }
+    }
+}

--- a/core/src/main/java/io/github/mabartos/evaluator/browser/BrowserEvaluatorConfig.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/browser/BrowserEvaluatorConfig.java
@@ -1,0 +1,32 @@
+package io.github.mabartos.evaluator.browser;
+
+import io.github.mabartos.evaluator.EvaluatorSettingUtils;
+import io.github.mabartos.spi.level.Risk;
+import org.keycloak.models.RealmModel;
+
+import static io.github.mabartos.spi.level.Risk.Score.MEDIUM;
+import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
+
+/**
+ * Realm-configurable settings for {@link BrowserRiskEvaluator}.
+ */
+public final class BrowserEvaluatorConfig {
+    public static final String KNOWN_BROWSER_SCORE_SETTING_KEY = "known-browser-score";
+    public static final String UNKNOWN_BROWSER_SCORE_SETTING_KEY = "unknown-browser-score";
+
+    public static final Risk.Score DEFAULT_KNOWN_BROWSER_SCORE = NEGATIVE_LOW;
+    public static final Risk.Score DEFAULT_UNKNOWN_BROWSER_SCORE = MEDIUM;
+
+    private BrowserEvaluatorConfig() {
+    }
+
+    public static Risk.Score knownBrowserScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, BrowserRiskEvaluator.class, KNOWN_BROWSER_SCORE_SETTING_KEY, DEFAULT_KNOWN_BROWSER_SCORE);
+    }
+
+    public static Risk.Score unknownBrowserScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, BrowserRiskEvaluator.class, UNKNOWN_BROWSER_SCORE_SETTING_KEY, DEFAULT_UNKNOWN_BROWSER_SCORE);
+    }
+}

--- a/core/src/main/java/io/github/mabartos/evaluator/browser/BrowserRiskEvaluator.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/browser/BrowserRiskEvaluator.java
@@ -28,9 +28,6 @@ import jakarta.annotation.Nonnull;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 
-import static io.github.mabartos.spi.level.Risk.Score.MEDIUM;
-import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
-
 /**
  * Risk evaluator for browser properties
  * Known browser = trust signal, unknown browser = moderate risk
@@ -46,7 +43,7 @@ public class BrowserRiskEvaluator extends DeviceRiskEvaluator {
     @Override
     public Risk evaluate(@Nonnull RealmModel realm) {
         return browserCondition.isDefaultKnownBrowser(realm)
-            ? Risk.of(NEGATIVE_LOW, "Known browser - trust signal")
-            : Risk.of(MEDIUM, "Unknown browser");
+                ? Risk.of(BrowserEvaluatorConfig.knownBrowserScore(realm), "Known browser - trust signal")
+                : Risk.of(BrowserEvaluatorConfig.unknownBrowserScore(realm), "Unknown browser");
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/browser/BrowserRiskEvaluatorFactory.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/browser/BrowserRiskEvaluatorFactory.java
@@ -16,9 +16,13 @@
  */
 package io.github.mabartos.evaluator.browser;
 
+import io.github.mabartos.evaluator.EvaluatorSettingProperties;
 import io.github.mabartos.spi.evaluator.RiskEvaluator;
 import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
 
 public class BrowserRiskEvaluatorFactory implements RiskEvaluatorFactory {
 
@@ -48,5 +52,21 @@ public class BrowserRiskEvaluatorFactory implements RiskEvaluatorFactory {
     @Override
     public Class<? extends RiskEvaluator> evaluatorClass() {
         return BrowserRiskEvaluator.class;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getAdditionalAdminConfigProperties() {
+        var evaluatorClass = BrowserRiskEvaluator.class;
+        return EvaluatorSettingProperties.of(
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, BrowserEvaluatorConfig.KNOWN_BROWSER_SCORE_SETTING_KEY,
+                        "Known browser score",
+                        "Risk score when the user agent matches a default known browser (Chrome, Firefox, Safari).",
+                        BrowserEvaluatorConfig.DEFAULT_KNOWN_BROWSER_SCORE),
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, BrowserEvaluatorConfig.UNKNOWN_BROWSER_SCORE_SETTING_KEY,
+                        "Unknown browser score",
+                        "Risk score when the user agent does not match a default known browser.",
+                        BrowserEvaluatorConfig.DEFAULT_UNKNOWN_BROWSER_SCORE));
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/location/KnownLocationEvaluatorConfig.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/location/KnownLocationEvaluatorConfig.java
@@ -1,0 +1,47 @@
+package io.github.mabartos.evaluator.location;
+
+import io.github.mabartos.evaluator.EvaluatorSettingUtils;
+import io.github.mabartos.spi.level.Risk;
+import org.keycloak.models.RealmModel;
+
+import static io.github.mabartos.spi.level.Risk.Score.MEDIUM;
+import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
+import static io.github.mabartos.spi.level.Risk.Score.VERY_SMALL;
+
+/**
+ * Realm-configurable settings for {@link KnownLocationRiskEvaluator}.
+ */
+public final class KnownLocationEvaluatorConfig {
+    public static final String FIRST_LOCATION_SCORE_SETTING_KEY = "first-location-score";
+    public static final String KNOWN_LOCATION_SCORE_SETTING_KEY = "known-location-score";
+    public static final String SAME_COUNTRY_SCORE_SETTING_KEY = "same-country-score";
+    public static final String NEW_COUNTRY_SCORE_SETTING_KEY = "new-country-score";
+
+    public static final Risk.Score DEFAULT_FIRST_LOCATION_SCORE = VERY_SMALL;
+    public static final Risk.Score DEFAULT_KNOWN_LOCATION_SCORE = NEGATIVE_LOW;
+    public static final Risk.Score DEFAULT_SAME_COUNTRY_SCORE = VERY_SMALL;
+    public static final Risk.Score DEFAULT_NEW_COUNTRY_SCORE = MEDIUM;
+
+    private KnownLocationEvaluatorConfig() {
+    }
+
+    public static Risk.Score firstLocationScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, KnownLocationRiskEvaluator.class, FIRST_LOCATION_SCORE_SETTING_KEY, DEFAULT_FIRST_LOCATION_SCORE);
+    }
+
+    public static Risk.Score knownLocationScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, KnownLocationRiskEvaluator.class, KNOWN_LOCATION_SCORE_SETTING_KEY, DEFAULT_KNOWN_LOCATION_SCORE);
+    }
+
+    public static Risk.Score sameCountryScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, KnownLocationRiskEvaluator.class, SAME_COUNTRY_SCORE_SETTING_KEY, DEFAULT_SAME_COUNTRY_SCORE);
+    }
+
+    public static Risk.Score newCountryScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, KnownLocationRiskEvaluator.class, NEW_COUNTRY_SCORE_SETTING_KEY, DEFAULT_NEW_COUNTRY_SCORE);
+    }
+}

--- a/core/src/main/java/io/github/mabartos/evaluator/location/KnownLocationRiskEvaluator.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/location/KnownLocationRiskEvaluator.java
@@ -2,7 +2,6 @@ package io.github.mabartos.evaluator.location;
 
 import io.github.mabartos.context.UserContexts;
 import io.github.mabartos.context.location.KnownLocationContext;
-import io.github.mabartos.context.location.KnownLocationContextFactory;
 import io.github.mabartos.context.location.LocationContext;
 import io.github.mabartos.context.location.LocationData;
 import io.github.mabartos.spi.level.Risk;
@@ -17,11 +16,8 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 
+import java.util.Objects;
 import java.util.Set;
-
-import static io.github.mabartos.spi.level.Risk.Score.MEDIUM;
-import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
-import static io.github.mabartos.spi.level.Risk.Score.VERY_SMALL;
 
 /**
  * Risk evaluator for location properties
@@ -38,6 +34,11 @@ public class KnownLocationRiskEvaluator extends AbstractRiskEvaluator {
         this.knownLocationContext = UserContexts.getContext(session, KnownLocationContext.class);
     }
 
+    KnownLocationRiskEvaluator(LocationContext locationContext, KnownLocationContext knownLocationContext) {
+        this.locationContext = locationContext;
+        this.knownLocationContext = knownLocationContext;
+    }
+
     @Override
     public Risk evaluate(@Nonnull RealmModel realm, @Nullable UserModel knownUser) {
         if (knownUser == null) {
@@ -51,38 +52,39 @@ public class KnownLocationRiskEvaluator extends AbstractRiskEvaluator {
 
         logger.tracef("Current location: %s", currentLocation.toString());
 
-        // Get known locations for this user from KnownLocationContext
         var knownLocations = knownLocationContext.getData(realm, knownUser).orElse(Set.of());
 
         if (knownLocations.isEmpty()) {
-            return Risk.of(VERY_SMALL, "First tracked location");
+            return Risk.of(KnownLocationEvaluatorConfig.firstLocationScore(realm), "First tracked location");
         }
 
-        return calculateLocationRisk(currentLocation, knownLocations);
+        return calculateLocationRisk(realm, currentLocation, knownLocations);
     }
 
-    protected Risk calculateLocationRisk(LocationData currentLocation, Set<LocationData> knownLocations) {
+    protected Risk calculateLocationRisk(
+            RealmModel realm, LocationData currentLocation, Set<LocationData> knownLocations) {
         if (currentLocation.getCountry() == null) {
             return Risk.invalid("Cannot determine country from IP address");
         }
 
-        // Check for exact match (same city and country)
         boolean exactMatch = knownLocations.stream()
                 .anyMatch(loc ->
-                        java.util.Objects.equals(loc.getCountry(), currentLocation.getCountry()) &&
-                        java.util.Objects.equals(loc.getCity(), currentLocation.getCity())
-                );
+                        Objects.equals(loc.getCountry(), currentLocation.getCountry()) &&
+                        Objects.equals(loc.getCity(), currentLocation.getCity()));
         if (exactMatch) {
-            return Risk.of(NEGATIVE_LOW, "Known location (city + country) - trust signal");
+            return Risk.of(
+                    KnownLocationEvaluatorConfig.knownLocationScore(realm),
+                    "Known location (city + country) - trust signal");
         }
 
-        // Check if the country has been seen before (even if city is different)
         boolean sameCountry = knownLocations.stream()
-                .anyMatch(loc -> java.util.Objects.equals(loc.getCountry(), currentLocation.getCountry()));
+                .anyMatch(loc -> Objects.equals(loc.getCountry(), currentLocation.getCountry()));
         if (sameCountry) {
-            return Risk.of(VERY_SMALL, "Same country, different city - minor anomaly");
+            return Risk.of(
+                    KnownLocationEvaluatorConfig.sameCountryScore(realm),
+                    "Same country, different city - minor anomaly");
         }
 
-        return Risk.of(MEDIUM, "Completely new country");
+        return Risk.of(KnownLocationEvaluatorConfig.newCountryScore(realm), "Completely new country");
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/location/KnownLocationRiskEvaluatorFactory.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/location/KnownLocationRiskEvaluatorFactory.java
@@ -16,12 +16,12 @@
  */
 package io.github.mabartos.evaluator.location;
 
-import io.github.mabartos.context.location.KnownLocationContext;
+import io.github.mabartos.context.location.KnownLocationSettings;
+import io.github.mabartos.evaluator.EvaluatorSettingProperties;
 import io.github.mabartos.spi.evaluator.RiskEvaluator;
 import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.provider.ProviderConfigProperty;
-import org.keycloak.provider.ProviderConfigurationBuilder;
 
 import java.util.List;
 
@@ -56,15 +56,40 @@ public class KnownLocationRiskEvaluatorFactory implements RiskEvaluatorFactory {
 
     @Override
     public List<ProviderConfigProperty> getAdditionalAdminConfigProperties() {
-        return ProviderConfigurationBuilder.create()
-                .property()
-                .name(KnownLocationContext.TTL_DAYS_CONFIG)
-                .label("TTL (days)")
-                .helpText("Number of days before a known location stops providing a trust signal. "
-                        + "Expired entries are removed on successful login. Set to 0 to disable expiration.")
-                .type(ProviderConfigProperty.INTEGER_TYPE)
-                .defaultValue(KnownLocationContext.DEFAULT_TTL_DAYS)
-                .add()
-                .build();
+        var evaluatorClass = KnownLocationRiskEvaluator.class;
+        return EvaluatorSettingProperties.of(
+                EvaluatorSettingProperties.intProperty(
+                        evaluatorClass, KnownLocationSettings.TTL_DAYS_SETTING_KEY,
+                        "TTL (days)",
+                        "Number of days before a known location stops providing a trust signal. "
+                                + "Expired entries are removed on successful login. Set to 0 to disable expiration.",
+                        KnownLocationSettings.DEFAULT_TTL_DAYS,
+                        0),
+                EvaluatorSettingProperties.intProperty(
+                        evaluatorClass, KnownLocationSettings.MAX_STORED_LOCATIONS_SETTING_KEY,
+                        "Max stored locations",
+                        "Maximum number of known locations kept per user (minimum 1).",
+                        KnownLocationSettings.DEFAULT_MAX_STORED_LOCATIONS,
+                        1),
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, KnownLocationEvaluatorConfig.FIRST_LOCATION_SCORE_SETTING_KEY,
+                        "First tracked location score",
+                        "Risk score when the user has no known locations yet.",
+                        KnownLocationEvaluatorConfig.DEFAULT_FIRST_LOCATION_SCORE),
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, KnownLocationEvaluatorConfig.KNOWN_LOCATION_SCORE_SETTING_KEY,
+                        "Known location score",
+                        "Risk score when city and country match a known location (trust signal).",
+                        KnownLocationEvaluatorConfig.DEFAULT_KNOWN_LOCATION_SCORE),
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, KnownLocationEvaluatorConfig.SAME_COUNTRY_SCORE_SETTING_KEY,
+                        "Same country score",
+                        "Risk score when the country was seen before but the city is new.",
+                        KnownLocationEvaluatorConfig.DEFAULT_SAME_COUNTRY_SCORE),
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, KnownLocationEvaluatorConfig.NEW_COUNTRY_SCORE_SETTING_KEY,
+                        "New country score",
+                        "Risk score when the login country was never seen before for this user.",
+                        KnownLocationEvaluatorConfig.DEFAULT_NEW_COUNTRY_SCORE));
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/login/LoginEventIpAddressEvaluatorConfig.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/login/LoginEventIpAddressEvaluatorConfig.java
@@ -1,0 +1,62 @@
+package io.github.mabartos.evaluator.login;
+
+import io.github.mabartos.evaluator.EvaluatorSettingUtils;
+import io.github.mabartos.spi.level.Risk;
+import org.keycloak.models.RealmModel;
+
+import static io.github.mabartos.spi.level.Risk.Score.HIGH;
+import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
+import static io.github.mabartos.spi.level.Risk.Score.VERY_SMALL;
+
+/**
+ * Realm-configurable settings for {@link LoginEventIpAddressRiskEvaluator}.
+ */
+public final class LoginEventIpAddressEvaluatorConfig {
+    public static final String NEVER_SEEN_IP_SCORE_SETTING_KEY = "never-seen-ip-score";
+    public static final String FREQUENT_IP_SCORE_SETTING_KEY = "frequent-ip-score";
+    public static final String OCCASIONAL_IP_SCORE_SETTING_KEY = "occasional-ip-score";
+    public static final String MIN_LOGIN_EVENTS_SETTING_KEY = "min-login-events";
+    public static final String FREQUENT_IP_THRESHOLD_DIVISOR_SETTING_KEY = "frequent-ip-threshold-divisor";
+
+    public static final Risk.Score DEFAULT_NEVER_SEEN_IP_SCORE = HIGH;
+    public static final Risk.Score DEFAULT_FREQUENT_IP_SCORE = NEGATIVE_LOW;
+    public static final Risk.Score DEFAULT_OCCASIONAL_IP_SCORE = VERY_SMALL;
+    public static final int DEFAULT_MIN_LOGIN_EVENTS = 4;
+    public static final int DEFAULT_FREQUENT_IP_THRESHOLD_DIVISOR = 3;
+
+    private LoginEventIpAddressEvaluatorConfig() {
+    }
+
+    public static Risk.Score neverSeenIpScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, LoginEventIpAddressRiskEvaluator.class, NEVER_SEEN_IP_SCORE_SETTING_KEY, DEFAULT_NEVER_SEEN_IP_SCORE);
+    }
+
+    public static Risk.Score frequentIpScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, LoginEventIpAddressRiskEvaluator.class, FREQUENT_IP_SCORE_SETTING_KEY, DEFAULT_FREQUENT_IP_SCORE);
+    }
+
+    public static Risk.Score occasionalIpScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, LoginEventIpAddressRiskEvaluator.class, OCCASIONAL_IP_SCORE_SETTING_KEY, DEFAULT_OCCASIONAL_IP_SCORE);
+    }
+
+    public static int minLoginEvents(RealmModel realm) {
+        return EvaluatorSettingUtils.getPositiveInt(
+                realm,
+                LoginEventIpAddressRiskEvaluator.class,
+                MIN_LOGIN_EVENTS_SETTING_KEY,
+                1,
+                DEFAULT_MIN_LOGIN_EVENTS);
+    }
+
+    public static int frequentIpThresholdDivisor(RealmModel realm) {
+        return EvaluatorSettingUtils.getPositiveInt(
+                realm,
+                LoginEventIpAddressRiskEvaluator.class,
+                FREQUENT_IP_THRESHOLD_DIVISOR_SETTING_KEY,
+                1,
+                DEFAULT_FREQUENT_IP_THRESHOLD_DIVISOR);
+    }
+}

--- a/core/src/main/java/io/github/mabartos/evaluator/login/LoginEventIpAddressRiskEvaluator.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/login/LoginEventIpAddressRiskEvaluator.java
@@ -17,10 +17,6 @@ import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
 
-import static io.github.mabartos.spi.level.Risk.Score.HIGH;
-import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
-import static io.github.mabartos.spi.level.Risk.Score.VERY_SMALL;
-
 /**
  * Evaluates risk based on IP address history.
  * Known IPs = trust signal, unknown IPs = risk signal
@@ -33,6 +29,12 @@ public class LoginEventIpAddressRiskEvaluator extends AbstractRiskEvaluator {
     public LoginEventIpAddressRiskEvaluator(KeycloakSession session) {
         this.loginEventsContext = UserContexts.getContext(session, KcLoginEventsContextFactory.PROVIDER_ID);
         this.deviceContext = UserContexts.getContext(session, DeviceRepresentationContext.class);
+    }
+
+    LoginEventIpAddressRiskEvaluator(
+            LoginEventsContext loginEventsContext, DeviceRepresentationContext deviceContext) {
+        this.loginEventsContext = loginEventsContext;
+        this.deviceContext = deviceContext;
     }
 
     @Override
@@ -56,24 +58,25 @@ public class LoginEventIpAddressRiskEvaluator extends AbstractRiskEvaluator {
                 .filter(f -> f.equals(deviceRepresentation.getIpAddress()))
                 .count();
 
-        if (numberOccurrences == 0) {
-            return Risk.of(HIGH, "IP address never seen before");
-        } else {
-            var eventsSize = events.size();
-            if (eventsSize > 3) {
-                long threshold = eventsSize / 3;
-                if (numberOccurrences >= threshold) {
-                    // Seen frequently - trust signal
-                    return Risk.of(NEGATIVE_LOW, "Frequently used IP address - trust signal");
-                } else {
-                    // Seen sometimes but not frequently
-                    return Risk.of(VERY_SMALL, "IP address seen occasionally");
-                }
-            } else {
-                // Not enough data
-                return Risk.invalid("Not enough login history");
-            }
-        }
+        return evaluateIpHistory(realm, numberOccurrences, events.size());
+    }
 
+    protected Risk evaluateIpHistory(RealmModel realm, long numberOccurrences, int eventsSize) {
+        if (numberOccurrences == 0) {
+            return Risk.of(
+                    LoginEventIpAddressEvaluatorConfig.neverSeenIpScore(realm), "IP address never seen before");
+        }
+        if (eventsSize >= LoginEventIpAddressEvaluatorConfig.minLoginEvents(realm)) {
+            int divisor = LoginEventIpAddressEvaluatorConfig.frequentIpThresholdDivisor(realm);
+            long threshold = eventsSize / divisor;
+            if (numberOccurrences >= threshold) {
+                return Risk.of(
+                        LoginEventIpAddressEvaluatorConfig.frequentIpScore(realm),
+                        "Frequently used IP address - trust signal");
+            }
+            return Risk.of(
+                    LoginEventIpAddressEvaluatorConfig.occasionalIpScore(realm), "IP address seen occasionally");
+        }
+        return Risk.invalid("Not enough login history");
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/login/LoginEventIpAddressRiskEvaluatorFactory.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/login/LoginEventIpAddressRiskEvaluatorFactory.java
@@ -1,8 +1,12 @@
 package io.github.mabartos.evaluator.login;
 
+import io.github.mabartos.evaluator.EvaluatorSettingProperties;
 import io.github.mabartos.spi.evaluator.RiskEvaluator;
 import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
 
 public class LoginEventIpAddressRiskEvaluatorFactory implements RiskEvaluatorFactory {
     public static final String PROVIDER_ID = "login-event-ip-address-risk-evaluator";
@@ -31,5 +35,40 @@ public class LoginEventIpAddressRiskEvaluatorFactory implements RiskEvaluatorFac
     @Override
     public String getId() {
         return PROVIDER_ID;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getAdditionalAdminConfigProperties() {
+        var evaluatorClass = LoginEventIpAddressRiskEvaluator.class;
+        return EvaluatorSettingProperties.of(
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, LoginEventIpAddressEvaluatorConfig.NEVER_SEEN_IP_SCORE_SETTING_KEY,
+                        "Never seen IP score",
+                        "Risk score when the current IP was never seen in the user's login history.",
+                        LoginEventIpAddressEvaluatorConfig.DEFAULT_NEVER_SEEN_IP_SCORE),
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, LoginEventIpAddressEvaluatorConfig.FREQUENT_IP_SCORE_SETTING_KEY,
+                        "Frequent IP score",
+                        "Risk score when the current IP appears often in recent login history (trust signal).",
+                        LoginEventIpAddressEvaluatorConfig.DEFAULT_FREQUENT_IP_SCORE),
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, LoginEventIpAddressEvaluatorConfig.OCCASIONAL_IP_SCORE_SETTING_KEY,
+                        "Occasional IP score",
+                        "Risk score when the current IP was seen before but not frequently enough.",
+                        LoginEventIpAddressEvaluatorConfig.DEFAULT_OCCASIONAL_IP_SCORE),
+                EvaluatorSettingProperties.intProperty(
+                        evaluatorClass, LoginEventIpAddressEvaluatorConfig.MIN_LOGIN_EVENTS_SETTING_KEY,
+                        "Min login events",
+                        "Minimum successful login events in history before classifying an IP as frequent or occasional. "
+                                + "Below this, the evaluator returns invalid.",
+                        LoginEventIpAddressEvaluatorConfig.DEFAULT_MIN_LOGIN_EVENTS,
+                        1),
+                EvaluatorSettingProperties.intProperty(
+                        evaluatorClass, LoginEventIpAddressEvaluatorConfig.FREQUENT_IP_THRESHOLD_DIVISOR_SETTING_KEY,
+                        "Frequent IP threshold divisor",
+                        "Current IP is frequent when its occurrence count is at least (event count / divisor). "
+                                + "Default 3 means one third of recent logins.",
+                        LoginEventIpAddressEvaluatorConfig.DEFAULT_FREQUENT_IP_THRESHOLD_DIVISOR,
+                        1));
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemEvaluatorConfig.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemEvaluatorConfig.java
@@ -1,0 +1,39 @@
+package io.github.mabartos.evaluator.os;
+
+import io.github.mabartos.evaluator.EvaluatorSettingUtils;
+import io.github.mabartos.spi.level.Risk;
+import org.keycloak.models.RealmModel;
+
+import static io.github.mabartos.spi.level.Risk.Score.MEDIUM;
+import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
+
+/**
+ * Realm-configurable settings for {@link OperatingSystemRiskEvaluator}.
+ */
+public final class OperatingSystemEvaluatorConfig {
+    public static final String KNOWN_OS_SCORE_SETTING_KEY = "known-os-score";
+    public static final String LEGACY_WINDOWS_SCORE_SETTING_KEY = "legacy-windows-score";
+    public static final String UNKNOWN_OS_SCORE_SETTING_KEY = "unknown-os-score";
+
+    public static final Risk.Score DEFAULT_KNOWN_OS_SCORE = NEGATIVE_LOW;
+    public static final Risk.Score DEFAULT_LEGACY_WINDOWS_SCORE = MEDIUM;
+    public static final Risk.Score DEFAULT_UNKNOWN_OS_SCORE = MEDIUM;
+
+    private OperatingSystemEvaluatorConfig() {
+    }
+
+    public static Risk.Score knownOsScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, OperatingSystemRiskEvaluator.class, KNOWN_OS_SCORE_SETTING_KEY, DEFAULT_KNOWN_OS_SCORE);
+    }
+
+    public static Risk.Score legacyWindowsScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, OperatingSystemRiskEvaluator.class, LEGACY_WINDOWS_SCORE_SETTING_KEY, DEFAULT_LEGACY_WINDOWS_SCORE);
+    }
+
+    public static Risk.Score unknownOsScore(RealmModel realm) {
+        return EvaluatorSettingUtils.getScore(
+                realm, OperatingSystemRiskEvaluator.class, UNKNOWN_OS_SCORE_SETTING_KEY, DEFAULT_UNKNOWN_OS_SCORE);
+    }
+}

--- a/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemRiskEvaluator.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemRiskEvaluator.java
@@ -29,9 +29,6 @@ import jakarta.annotation.Nonnull;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 
-import static io.github.mabartos.spi.level.Risk.Score.MEDIUM;
-import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
-
 /**
  * Risk evaluator for OS properties.
  * Linux, macOS, and recent Windows (10/11) reduce risk; legacy Windows and unknown OS score moderate risk.
@@ -44,17 +41,21 @@ public class OperatingSystemRiskEvaluator extends DeviceRiskEvaluator {
         this.condition = UserContexts.getContextCondition(session, OperatingSystemConditionFactory.PROVIDER_ID);
     }
 
+    OperatingSystemRiskEvaluator(OperatingSystemCondition condition) {
+        this.condition = condition;
+    }
+
     @Override
     public Risk evaluate(@Nonnull RealmModel realm) {
         if (condition.isTrustedOs(realm)) {
             if (condition.isOs(realm, DefaultOperatingSystems.WINDOWS)) {
-                return Risk.of(NEGATIVE_LOW, "Recent Windows - trust signal");
+                return Risk.of(OperatingSystemEvaluatorConfig.knownOsScore(realm), "Recent Windows - trust signal");
             }
-            return Risk.of(NEGATIVE_LOW, "Known OS - trust signal");
+            return Risk.of(OperatingSystemEvaluatorConfig.knownOsScore(realm), "Known OS - trust signal");
         }
         if (condition.isLegacyWindows(realm)) {
-            return Risk.of(MEDIUM, "Legacy Windows");
+            return Risk.of(OperatingSystemEvaluatorConfig.legacyWindowsScore(realm), "Legacy Windows");
         }
-        return Risk.of(MEDIUM, "Unknown OS");
+        return Risk.of(OperatingSystemEvaluatorConfig.unknownOsScore(realm), "Unknown OS");
     }
 }

--- a/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemRiskEvaluatorFactory.java
+++ b/core/src/main/java/io/github/mabartos/evaluator/os/OperatingSystemRiskEvaluatorFactory.java
@@ -16,9 +16,13 @@
  */
 package io.github.mabartos.evaluator.os;
 
+import io.github.mabartos.evaluator.EvaluatorSettingProperties;
 import io.github.mabartos.spi.evaluator.RiskEvaluator;
 import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.provider.ProviderConfigProperty;
+
+import java.util.List;
 
 public class OperatingSystemRiskEvaluatorFactory implements RiskEvaluatorFactory {
     public static final String PROVIDER_ID = "default-operating-system-risk-evaluator-factory";
@@ -47,5 +51,26 @@ public class OperatingSystemRiskEvaluatorFactory implements RiskEvaluatorFactory
     @Override
     public Class<? extends RiskEvaluator> evaluatorClass() {
         return OperatingSystemRiskEvaluator.class;
+    }
+
+    @Override
+    public List<ProviderConfigProperty> getAdditionalAdminConfigProperties() {
+        var evaluatorClass = OperatingSystemRiskEvaluator.class;
+        return EvaluatorSettingProperties.of(
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, OperatingSystemEvaluatorConfig.KNOWN_OS_SCORE_SETTING_KEY,
+                        "Known OS score",
+                        "Risk score for Linux, macOS, or recent Windows (10/11) detected from the user agent.",
+                        OperatingSystemEvaluatorConfig.DEFAULT_KNOWN_OS_SCORE),
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, OperatingSystemEvaluatorConfig.LEGACY_WINDOWS_SCORE_SETTING_KEY,
+                        "Legacy Windows score",
+                        "Risk score for older Windows versions not treated as trusted.",
+                        OperatingSystemEvaluatorConfig.DEFAULT_LEGACY_WINDOWS_SCORE),
+                EvaluatorSettingProperties.scoreProperty(
+                        evaluatorClass, OperatingSystemEvaluatorConfig.UNKNOWN_OS_SCORE_SETTING_KEY,
+                        "Unknown OS score",
+                        "Risk score when the operating system cannot be classified from the user agent.",
+                        OperatingSystemEvaluatorConfig.DEFAULT_UNKNOWN_OS_SCORE));
     }
 }

--- a/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
+++ b/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
@@ -18,6 +18,8 @@ package io.github.mabartos.ui;
 
 import io.github.mabartos.audit.admin.AdaptiveAdminAudit;
 import io.github.mabartos.audit.admin.RiskPoliciesSettingsSnapshot;
+import io.github.mabartos.evaluator.EvaluatorIntegerConfigProperty;
+import io.github.mabartos.evaluator.EvaluatorSettingUtils;
 import io.github.mabartos.evaluator.EvaluatorUtils;
 import io.github.mabartos.level.Trust;
 import io.github.mabartos.spi.engine.RiskScoreAlgorithm;
@@ -211,9 +213,18 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
             var key = prop.getName();
             if (model.contains(key)) {
                 storeRealmAttributeFromModel(model, realm, key, context);
-            } else if (realm.getAttribute(key) == null && prop.getDefaultValue() != null) {
-                logger.debugf("%s setting evaluator default '%s' = '%s'", context, key, prop.getDefaultValue());
-                realm.setAttribute(key, prop.getDefaultValue().toString());
+            } else if (StringUtil.isBlank(realm.getAttribute(key))) {
+                var persisted = resolvePersistedTabComponent(realm, model);
+                if (persisted != null
+                        && persisted.getConfig().containsKey(key)
+                        && StringUtil.isNotBlank(persisted.get(key))) {
+                    logger.debugf("%s migrating component evaluator setting '%s' = '%s' to realm",
+                            context, key, persisted.get(key));
+                    realm.setAttribute(key, persisted.get(key));
+                } else if (prop.getDefaultValue() != null) {
+                    logger.debugf("%s setting evaluator default '%s' = '%s'", context, key, prop.getDefaultValue());
+                    realm.setAttribute(key, prop.getDefaultValue().toString());
+                }
             }
         });
     }
@@ -223,6 +234,7 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
         logger.tracef("validateConfiguration execution");
 
         validateEvaluatorTrustValues(model);
+        validateAdditionalEvaluatorSettings(model);
 
         var persisted = resolvePersistedTabComponent(realm, model);
         hydrateModelFromRealmAttributes(realm, model, persisted);
@@ -253,6 +265,35 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
         });
     }
 
+    private void validateAdditionalEvaluatorSettings(ComponentModel model) {
+        riskEvaluatorFactories.forEach(factory -> factory.getAdditionalAdminConfigProperties().forEach(prop -> {
+            var value = model.get(prop.getName());
+            if (StringUtil.isBlank(value)) {
+                return;
+            }
+            if (isScoreListProperty(prop)) {
+                if (!EvaluatorSettingUtils.isValidScoreName(value)) {
+                    throw new ComponentValidationException(String.format(
+                            "%s must be one of: %s",
+                            prop.getLabel(),
+                            String.join(", ", EvaluatorSettingUtils.configurableScoreNames())));
+                }
+                return;
+            }
+            if (prop instanceof EvaluatorIntegerConfigProperty intProp) {
+                validateIntegerAtLeast(value, intProp.getMinimum(), prop.getLabel());
+            } else if (ProviderConfigProperty.INTEGER_TYPE.equals(prop.getType())) {
+                validateInteger(value, prop.getLabel());
+            }
+        }));
+    }
+
+    private static boolean isScoreListProperty(ProviderConfigProperty prop) {
+        return ProviderConfigProperty.LIST_TYPE.equals(prop.getType())
+                && prop.getOptions() != null
+                && prop.getOptions().equals(EvaluatorSettingUtils.configurableScoreNames());
+    }
+
     private void populateMissingDefaults(ComponentModel model) {
         getConfigProperties().forEach(prop -> {
             if (model.get(prop.getName()) == null && prop.getDefaultValue() != null) {
@@ -276,6 +317,13 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
             var key = prop.getName();
             var realmValue = realm.getAttribute(key);
             if (isRealmSourcedEvaluatorSetting(key) || isAdditionalAdminConfigKey(key)) {
+                if (isAdditionalAdminConfigKey(key)
+                        && persisted == null
+                        && StringUtil.isBlank(realmValue)
+                        && StringUtil.isNotBlank(model.get(key))) {
+                    logger.tracef("Keeping first-save additional evaluator setting '%s' = '%s'", key, model.get(key));
+                    return;
+                }
                 applyRealmSourcedEvaluatorSettingHydration(model, persisted, key, realmValue);
                 return;
             }
@@ -367,6 +415,17 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
             }
         } catch (NumberFormatException e) {
             throw new ComponentValidationException(String.format("%s must be positive number or 0", attributeDisplayName));
+        }
+    }
+
+    protected void validateIntegerAtLeast(String value, int minimum, String attributeDisplayName) {
+        try {
+            if (Integer.parseInt(value) < minimum) {
+                throw new NumberFormatException();
+            }
+        } catch (NumberFormatException e) {
+            throw new ComponentValidationException(
+                    String.format("%s must be at least %d", attributeDisplayName, minimum));
         }
     }
 
@@ -504,9 +563,17 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
 
     private static ProviderConfigProperty withEvaluatorSettingLabel(
             RiskEvaluatorFactory factory, ProviderConfigProperty prop) {
+        var label = RiskEvaluatorUi.additionalSettingLabel(factory, prop.getLabel());
+        if (prop instanceof EvaluatorIntegerConfigProperty intProp) {
+            var defaultValue = prop.getDefaultValue() instanceof Number number
+                    ? number.intValue()
+                    : intProp.getMinimum();
+            return new EvaluatorIntegerConfigProperty(
+                    prop.getName(), label, prop.getHelpText(), defaultValue, intProp.getMinimum());
+        }
         var labeled = new ProviderConfigProperty();
         labeled.setName(prop.getName());
-        labeled.setLabel(RiskEvaluatorUi.additionalSettingLabel(factory, prop.getLabel()));
+        labeled.setLabel(label);
         labeled.setHelpText(prop.getHelpText());
         labeled.setType(prop.getType());
         labeled.setDefaultValue(prop.getDefaultValue());

--- a/core/src/test/java/io/github/mabartos/evaluator/EvaluatorSettingUtilsTest.java
+++ b/core/src/test/java/io/github/mabartos/evaluator/EvaluatorSettingUtilsTest.java
@@ -1,0 +1,119 @@
+package io.github.mabartos.evaluator;
+
+import io.github.mabartos.evaluator.location.KnownLocationRiskEvaluator;
+import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
+import io.github.mabartos.spi.level.Risk;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.github.mabartos.test.RealmModelTestSupport.realmWithAttributes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EvaluatorSettingUtilsTest {
+
+    private static final String SETTING_KEY = "new-country-score";
+    private static final String ATTRIBUTE_KEY = RiskEvaluatorFactory.getAdditionalSettingConfig(
+            KnownLocationRiskEvaluator.class, SETTING_KEY);
+
+    @Test
+    void getScore_returnsDefaultWhenAttributeMissing() {
+        var realm = realmWithAttributes(Map.of());
+
+        var score = EvaluatorSettingUtils.getScore(
+                realm, KnownLocationRiskEvaluator.class, SETTING_KEY, Risk.Score.MEDIUM);
+
+        assertEquals(Risk.Score.MEDIUM, score);
+    }
+
+    @Test
+    void getScore_returnsConfiguredValue() {
+        var realm = realmWithAttributes(Map.of(ATTRIBUTE_KEY, "HIGH"));
+
+        var score = EvaluatorSettingUtils.getScore(
+                realm, KnownLocationRiskEvaluator.class, SETTING_KEY, Risk.Score.MEDIUM);
+
+        assertEquals(Risk.Score.HIGH, score);
+    }
+
+    @Test
+    void getScore_returnsDefaultForInvalidValue() {
+        var realm = realmWithAttributes(Map.of(ATTRIBUTE_KEY, "NOT_A_SCORE"));
+
+        var score = EvaluatorSettingUtils.getScore(
+                realm, KnownLocationRiskEvaluator.class, SETTING_KEY, Risk.Score.MEDIUM);
+
+        assertEquals(Risk.Score.MEDIUM, score);
+    }
+
+    @Test
+    void getInt_returnsDefaultWhenAttributeMissing() {
+        var realm = realmWithAttributes(Map.of());
+
+        assertEquals(10, EvaluatorSettingUtils.getInt(realm, KnownLocationRiskEvaluator.class, "ttl-days", 10));
+    }
+
+    @Test
+    void getInt_returnsConfiguredValue() {
+        var key = RiskEvaluatorFactory.getAdditionalSettingConfig(KnownLocationRiskEvaluator.class, "ttl-days");
+        var realm = realmWithAttributes(Map.of(key, "45"));
+
+        assertEquals(45, EvaluatorSettingUtils.getInt(realm, KnownLocationRiskEvaluator.class, "ttl-days", 90));
+    }
+
+    @Test
+    void getInt_returnsDefaultForNegativeValue() {
+        var key = RiskEvaluatorFactory.getAdditionalSettingConfig(KnownLocationRiskEvaluator.class, "ttl-days");
+        var realm = realmWithAttributes(Map.of(key, "-1"));
+
+        assertEquals(90, EvaluatorSettingUtils.getInt(realm, KnownLocationRiskEvaluator.class, "ttl-days", 90));
+    }
+
+    @Test
+    void getInt_returnsDefaultForNonNumericValue() {
+        var key = RiskEvaluatorFactory.getAdditionalSettingConfig(KnownLocationRiskEvaluator.class, "ttl-days");
+        var realm = realmWithAttributes(Map.of(key, "abc"));
+
+        assertEquals(90, EvaluatorSettingUtils.getInt(realm, KnownLocationRiskEvaluator.class, "ttl-days", 90));
+    }
+
+    @Test
+    void getPositiveInt_enforcesMinimum() {
+        var key = RiskEvaluatorFactory.getAdditionalSettingConfig(KnownLocationRiskEvaluator.class, "max-stored-locations");
+        var realm = realmWithAttributes(Map.of(key, "0"));
+
+        assertEquals(10, EvaluatorSettingUtils.getPositiveInt(
+                realm, KnownLocationRiskEvaluator.class, "max-stored-locations", 1, 10));
+    }
+
+    @Test
+    void getPositiveInt_returnsValueAtMinimum() {
+        var key = RiskEvaluatorFactory.getAdditionalSettingConfig(KnownLocationRiskEvaluator.class, "max-stored-locations");
+        var realm = realmWithAttributes(Map.of(key, "1"));
+
+        assertEquals(1, EvaluatorSettingUtils.getPositiveInt(
+                realm, KnownLocationRiskEvaluator.class, "max-stored-locations", 1, 10));
+    }
+
+    @Test
+    void attributeKey_followsConvention() {
+        assertEquals(
+                "adaptive-evaluator-ttl-days-KnownLocationRiskEvaluator",
+                RiskEvaluatorFactory.getAdditionalSettingConfig(KnownLocationRiskEvaluator.class, "ttl-days"));
+    }
+
+    @Test
+    void configurableScoreNames_excludesInvalid() {
+        assertFalse(EvaluatorSettingUtils.configurableScoreNames().contains(Risk.Score.INVALID.name()));
+        assertTrue(EvaluatorSettingUtils.configurableScoreNames().contains(Risk.Score.HIGH.name()));
+    }
+
+    @Test
+    void isValidScoreName_acceptsKnownScores() {
+        assertTrue(EvaluatorSettingUtils.isValidScoreName("HIGH"));
+        assertFalse(EvaluatorSettingUtils.isValidScoreName("INVALID"));
+        assertFalse(EvaluatorSettingUtils.isValidScoreName("unknown"));
+    }
+}

--- a/core/src/test/java/io/github/mabartos/evaluator/location/KnownLocationRiskEvaluatorTest.java
+++ b/core/src/test/java/io/github/mabartos/evaluator/location/KnownLocationRiskEvaluatorTest.java
@@ -1,0 +1,84 @@
+package io.github.mabartos.evaluator.location;
+
+import io.github.mabartos.context.location.KnownLocationData;
+import io.github.mabartos.context.location.LocationData;
+import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
+import io.github.mabartos.spi.level.Risk;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.RealmModel;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.github.mabartos.evaluator.location.KnownLocationEvaluatorConfig.NEW_COUNTRY_SCORE_SETTING_KEY;
+import static io.github.mabartos.spi.level.Risk.Score.HIGH;
+import static io.github.mabartos.spi.level.Risk.Score.MEDIUM;
+import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
+import static io.github.mabartos.spi.level.Risk.Score.VERY_SMALL;
+import static io.github.mabartos.test.RealmModelTestSupport.realmWithAttributes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class KnownLocationRiskEvaluatorTest {
+
+    private final TestEvaluator evaluator = new TestEvaluator();
+
+    @Test
+    void calculateLocationRisk_returnsNewCountryScoreByDefault() {
+        var realm = realmWithAttributes(Map.of());
+        var current = location("Germany", "Berlin");
+        var known = Set.of(location("France", "Paris"));
+
+        var risk = evaluator.calculate(realm, current, known);
+
+        assertEquals(MEDIUM, risk.getScore());
+    }
+
+    @Test
+    void calculateLocationRisk_usesConfiguredNewCountryScore() {
+        var key = RiskEvaluatorFactory.getAdditionalSettingConfig(
+                KnownLocationRiskEvaluator.class, NEW_COUNTRY_SCORE_SETTING_KEY);
+        var realm = realmWithAttributes(Map.of(key, "HIGH"));
+        var current = location("Germany", "Berlin");
+        var known = Set.of(location("France", "Paris"));
+
+        var risk = evaluator.calculate(realm, current, known);
+
+        assertEquals(HIGH, risk.getScore());
+    }
+
+    @Test
+    void calculateLocationRisk_returnsKnownLocationScoreForExactMatch() {
+        var realm = realmWithAttributes(Map.of());
+        var current = location("France", "Paris");
+        var known = Set.of(location("France", "Paris"), location("Germany", "Berlin"));
+
+        var risk = evaluator.calculate(realm, current, known);
+
+        assertEquals(NEGATIVE_LOW, risk.getScore());
+    }
+
+    @Test
+    void calculateLocationRisk_returnsSameCountryScore() {
+        var realm = realmWithAttributes(Map.of());
+        var current = location("France", "Lyon");
+        var known = Set.of(location("France", "Paris"));
+
+        var risk = evaluator.calculate(realm, current, known);
+
+        assertEquals(VERY_SMALL, risk.getScore());
+    }
+
+    private static LocationData location(String country, String city) {
+        return KnownLocationData.of(country, city, 1L);
+    }
+
+    private static final class TestEvaluator extends KnownLocationRiskEvaluator {
+        TestEvaluator() {
+            super(null, null);
+        }
+
+        Risk calculate(RealmModel realm, LocationData current, Set<LocationData> known) {
+            return calculateLocationRisk(realm, current, known);
+        }
+    }
+}

--- a/core/src/test/java/io/github/mabartos/evaluator/login/LoginEventIpAddressRiskEvaluatorTest.java
+++ b/core/src/test/java/io/github/mabartos/evaluator/login/LoginEventIpAddressRiskEvaluatorTest.java
@@ -1,0 +1,92 @@
+package io.github.mabartos.evaluator.login;
+
+import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
+import io.github.mabartos.spi.level.Risk;
+import org.junit.jupiter.api.Test;
+import org.keycloak.models.RealmModel;
+
+import java.util.Map;
+
+import static io.github.mabartos.spi.level.Risk.Score.HIGH;
+import static io.github.mabartos.spi.level.Risk.Score.INVALID;
+import static io.github.mabartos.spi.level.Risk.Score.NEGATIVE_LOW;
+import static io.github.mabartos.spi.level.Risk.Score.SMALL;
+import static io.github.mabartos.spi.level.Risk.Score.VERY_SMALL;
+import static io.github.mabartos.test.RealmModelTestSupport.realmWithAttributes;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LoginEventIpAddressRiskEvaluatorTest {
+
+    private final TestEvaluator evaluator = new TestEvaluator();
+
+    @Test
+    void evaluateIpHistory_returnsNeverSeenScore() {
+        var risk = evaluator.evaluateHistory(realmWithAttributes(Map.of()), 0, 10);
+
+        assertEquals(HIGH, risk.getScore());
+    }
+
+    @Test
+    void evaluateIpHistory_returnsFrequentIpScore() {
+        var risk = evaluator.evaluateHistory(realmWithAttributes(Map.of()), 4, 12);
+
+        assertEquals(NEGATIVE_LOW, risk.getScore());
+    }
+
+    @Test
+    void evaluateIpHistory_returnsOccasionalIpScore() {
+        var risk = evaluator.evaluateHistory(realmWithAttributes(Map.of()), 2, 12);
+
+        assertEquals(VERY_SMALL, risk.getScore());
+    }
+
+    @Test
+    void evaluateIpHistory_returnsInvalidWhenNotEnoughHistory() {
+        var risk = evaluator.evaluateHistory(realmWithAttributes(Map.of()), 1, 3);
+
+        assertEquals(INVALID, risk.getScore());
+    }
+
+    @Test
+    void evaluateIpHistory_usesConfiguredNeverSeenScore() {
+        var key = RiskEvaluatorFactory.getAdditionalSettingConfig(
+                LoginEventIpAddressRiskEvaluator.class,
+                LoginEventIpAddressEvaluatorConfig.NEVER_SEEN_IP_SCORE_SETTING_KEY);
+
+        var risk = evaluator.evaluateHistory(realmWithAttributes(Map.of(key, "SMALL")), 0, 10);
+
+        assertEquals(SMALL, risk.getScore());
+    }
+
+    @Test
+    void evaluateIpHistory_usesConfiguredMinLoginEvents() {
+        var minEventsKey = RiskEvaluatorFactory.getAdditionalSettingConfig(
+                LoginEventIpAddressRiskEvaluator.class,
+                LoginEventIpAddressEvaluatorConfig.MIN_LOGIN_EVENTS_SETTING_KEY);
+
+        var risk = evaluator.evaluateHistory(realmWithAttributes(Map.of(minEventsKey, "2")), 1, 6);
+
+        assertEquals(VERY_SMALL, risk.getScore());
+    }
+
+    @Test
+    void evaluateIpHistory_usesConfiguredFrequentIpThresholdDivisor() {
+        var divisorKey = RiskEvaluatorFactory.getAdditionalSettingConfig(
+                LoginEventIpAddressRiskEvaluator.class,
+                LoginEventIpAddressEvaluatorConfig.FREQUENT_IP_THRESHOLD_DIVISOR_SETTING_KEY);
+
+        var risk = evaluator.evaluateHistory(realmWithAttributes(Map.of(divisorKey, "4")), 3, 12);
+
+        assertEquals(NEGATIVE_LOW, risk.getScore());
+    }
+
+    private static final class TestEvaluator extends LoginEventIpAddressRiskEvaluator {
+        TestEvaluator() {
+            super(null, null);
+        }
+
+        Risk evaluateHistory(RealmModel realm, long numberOccurrences, int eventsSize) {
+            return evaluateIpHistory(realm, numberOccurrences, eventsSize);
+        }
+    }
+}

--- a/core/src/test/java/io/github/mabartos/test/RealmModelTestSupport.java
+++ b/core/src/test/java/io/github/mabartos/test/RealmModelTestSupport.java
@@ -1,0 +1,39 @@
+package io.github.mabartos.test;
+
+import org.keycloak.models.RealmModel;
+
+import java.util.Map;
+
+/**
+ * Minimal {@link RealmModel} test double backed by a realm-attribute map.
+ */
+public final class RealmModelTestSupport {
+
+    private RealmModelTestSupport() {
+    }
+
+    public static RealmModel realmWithAttributes(Map<String, String> attributes) {
+        return (RealmModel) java.lang.reflect.Proxy.newProxyInstance(
+                RealmModel.class.getClassLoader(),
+                new Class<?>[] {RealmModel.class},
+                (proxy, method, args) -> {
+                    if ("getAttribute".equals(method.getName()) && args != null && args.length == 1) {
+                        return attributes.get(args[0].toString());
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == int.class) {
+            return 0;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        return null;
+    }
+}

--- a/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
+++ b/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
@@ -502,6 +502,22 @@ class RiskBasedPoliciesUiTabPersistenceTest {
         assertEquals(String.valueOf(KnownLocationContext.DEFAULT_TTL_DAYS), model.get(KnownLocationContext.TTL_DAYS_CONFIG));
     }
 
+
+    @Test
+    void onUpdate_migratesStaleComponentAdditionalSettingToRealm() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+        var persisted = tabComponent(Map.of(KnownLocationContext.TTL_DAYS_CONFIG, "180"));
+        persisted.setId("risk-tab");
+        var newModel = componentModel(Map.of());
+        newModel.setId("risk-tab");
+        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
+
+        tab.onUpdate(null, realm, persisted, newModel);
+
+        assertEquals("180", realmAttributes.get(KnownLocationContext.TTL_DAYS_CONFIG));
+    }
+
     private static ComponentModel componentModel(Map<String, String> entries) {
         var model = new ComponentModel();
         entries.forEach((key, value) -> model.getConfig().putSingle(key, value));

--- a/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
+++ b/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
@@ -4,6 +4,9 @@ import io.github.mabartos.evaluator.EvaluatorUtils;
 import io.github.mabartos.evaluator.browser.BrowserRiskEvaluator;
 import io.github.mabartos.evaluator.browser.BrowserRiskEvaluatorFactory;
 import io.github.mabartos.context.location.KnownLocationContext;
+import io.github.mabartos.context.location.KnownLocationSettings;
+import io.github.mabartos.evaluator.location.KnownLocationEvaluatorConfig;
+import io.github.mabartos.evaluator.location.KnownLocationRiskEvaluator;
 import io.github.mabartos.evaluator.location.KnownLocationRiskEvaluatorFactory;
 import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,6 +25,7 @@ import static io.github.mabartos.ui.RiskBasedPoliciesUiTab.RISK_BASED_AUTHN_ENAB
 import static io.github.mabartos.spi.engine.RiskEngineFactory.EVALUATOR_TIMEOUT_CONFIG;
 import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.getTrustConfig;
 import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.isEnabledConfig;
+import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.getAdditionalSettingConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -488,22 +492,6 @@ class RiskBasedPoliciesUiTabPersistenceTest {
     }
 
     @Test
-    void validateConfiguration_discardsStaleModelTtlWhenNoRealmAttribute() throws Exception {
-        var factory = new KnownLocationRiskEvaluatorFactory();
-        injectFactories(tab, List.of(factory));
-        var persisted = tabComponent(Map.of(KnownLocationContext.TTL_DAYS_CONFIG, "180"));
-        persisted.setId("risk-tab");
-        var model = componentModel(Map.of(KnownLocationContext.TTL_DAYS_CONFIG, "180"));
-        model.setId("risk-tab");
-        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
-
-        tab.validateConfiguration(null, realm, model);
-
-        assertEquals(String.valueOf(KnownLocationContext.DEFAULT_TTL_DAYS), model.get(KnownLocationContext.TTL_DAYS_CONFIG));
-    }
-
-
-    @Test
     void onUpdate_migratesStaleComponentAdditionalSettingToRealm() throws Exception {
         var factory = new KnownLocationRiskEvaluatorFactory();
         injectFactories(tab, List.of(factory));
@@ -516,6 +504,76 @@ class RiskBasedPoliciesUiTabPersistenceTest {
         tab.onUpdate(null, realm, persisted, newModel);
 
         assertEquals("180", realmAttributes.get(KnownLocationContext.TTL_DAYS_CONFIG));
+    }
+
+    @Test
+    void onUpdate_persistsKnownLocationNewCountryScore() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+        var key = getAdditionalSettingConfig(
+                KnownLocationRiskEvaluator.class, KnownLocationEvaluatorConfig.NEW_COUNTRY_SCORE_SETTING_KEY);
+        var oldModel = componentModel(Map.of());
+        var newModel = componentModel(Map.of(key, "HIGH"));
+
+        tab.onUpdate(null, realm, oldModel, newModel);
+
+        assertEquals("HIGH", realmAttributes.get(key));
+    }
+
+    @Test
+    void validateConfiguration_rejectsInvalidKnownLocationScore() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+        var key = getAdditionalSettingConfig(
+                KnownLocationRiskEvaluator.class, KnownLocationEvaluatorConfig.NEW_COUNTRY_SCORE_SETTING_KEY);
+        var model = componentModel(Map.of(key, "NOT_A_SCORE"));
+
+        assertThrows(ComponentValidationException.class,
+                () -> tab.validateConfiguration(null, realm, model));
+    }
+
+    @Test
+    void validateConfiguration_rejectsMaxStoredLocationsZero() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+        var model = componentModel(Map.of(KnownLocationSettings.MAX_STORED_LOCATIONS_CONFIG, "0"));
+
+        assertThrows(ComponentValidationException.class,
+                () -> tab.validateConfiguration(null, realm, model));
+    }
+
+    @Test
+    void validateConfiguration_rejectsNegativeTtlDays() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+        var model = componentModel(Map.of(KnownLocationContext.TTL_DAYS_CONFIG, "-1"));
+
+        assertThrows(ComponentValidationException.class,
+                () -> tab.validateConfiguration(null, realm, model));
+    }
+
+    @Test
+    void validateConfiguration_acceptsTtlDaysZero() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+        var model = componentModel(Map.of(KnownLocationContext.TTL_DAYS_CONFIG, "0"));
+
+        tab.validateConfiguration(null, realm, model);
+    }
+
+    @Test
+    void validateConfiguration_discardsStaleModelTtlWhenNoRealmAttribute() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+        var persisted = tabComponent(Map.of(KnownLocationContext.TTL_DAYS_CONFIG, "180"));
+        persisted.setId("risk-tab");
+        var model = componentModel(Map.of(KnownLocationContext.TTL_DAYS_CONFIG, "180"));
+        model.setId("risk-tab");
+        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals(String.valueOf(KnownLocationContext.DEFAULT_TTL_DAYS), model.get(KnownLocationContext.TTL_DAYS_CONFIG));
     }
 
     private static ComponentModel componentModel(Map<String, String> entries) {

--- a/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabTest.java
+++ b/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabTest.java
@@ -4,6 +4,8 @@ import io.github.mabartos.evaluator.behavior.ConcurrentSessionRiskEvaluatorFacto
 import io.github.mabartos.evaluator.browser.BrowserRiskEvaluatorFactory;
 import io.github.mabartos.evaluator.client.ClientSensitivityRiskEvaluatorFactory;
 import io.github.mabartos.context.location.KnownLocationContext;
+import io.github.mabartos.evaluator.location.KnownLocationEvaluatorConfig;
+import io.github.mabartos.evaluator.location.KnownLocationRiskEvaluator;
 import io.github.mabartos.evaluator.location.KnownLocationRiskEvaluatorFactory;
 import io.github.mabartos.evaluator.role.DefaultUserRoleEvaluatorFactory;
 import io.github.mabartos.spi.evaluator.RiskEvaluatorFactory;
@@ -12,6 +14,7 @@ import org.keycloak.provider.ProviderConfigProperty;
 
 import java.util.List;
 
+import static io.github.mabartos.spi.evaluator.RiskEvaluatorFactory.getAdditionalSettingConfig;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -70,10 +73,12 @@ class RiskBasedPoliciesUiTabTest {
     }
 
     @Test
-    void buildConfigProperties_includesEvaluatorSpecificProperties() {
+    void buildConfigProperties_includesKnownLocationEvaluatorSettings() {
         var factories = List.<RiskEvaluatorFactory>of(new KnownLocationRiskEvaluatorFactory());
 
-        var ttl = RiskBasedPoliciesUiTab.buildConfigProperties(List.of(), factories).stream()
+        var props = RiskBasedPoliciesUiTab.buildConfigProperties(List.of(), factories);
+
+        var ttl = props.stream()
                 .filter(p -> KnownLocationContext.TTL_DAYS_CONFIG.equals(p.getName()))
                 .findFirst()
                 .orElseThrow();
@@ -81,6 +86,16 @@ class RiskBasedPoliciesUiTabTest {
         assertEquals("[USER_KNOWN] Known location TTL (days)", ttl.getLabel());
         assertEquals(ProviderConfigProperty.INTEGER_TYPE, ttl.getType());
         assertEquals(KnownLocationContext.DEFAULT_TTL_DAYS, ttl.getDefaultValue());
+
+        var newCountryScore = props.stream()
+                .filter(p -> getAdditionalSettingConfig(
+                        KnownLocationRiskEvaluator.class,
+                        KnownLocationEvaluatorConfig.NEW_COUNTRY_SCORE_SETTING_KEY).equals(p.getName()))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(ProviderConfigProperty.LIST_TYPE, newCountryScore.getType());
+        assertEquals("MEDIUM", newCountryScore.getDefaultValue());
     }
 
     private static List<String> evaluatorEnabledLabels(List<ProviderConfigProperty> props) {

--- a/docs/evaluator-settings.md
+++ b/docs/evaluator-settings.md
@@ -10,17 +10,47 @@ adaptive-evaluator-{settingKey}-{EvaluatorSimpleClassName}
 
 Built with `RiskEvaluatorFactory.getAdditionalSettingConfig(evaluatorClass, settingKey)`.
 
-Example for Known location TTL:
+Example for Known location:
 
 | Realm attribute | Default | Effect |
 |-----------------|---------|--------|
 | `adaptive-evaluator-ttl-days-KnownLocationRiskEvaluator` | `90` | Days before a known location stops providing a trust signal |
+| `adaptive-evaluator-max-stored-locations-KnownLocationRiskEvaluator` | `10` | Maximum known locations kept per user (minimum `1`) |
+| `adaptive-evaluator-first-location-score-KnownLocationRiskEvaluator` | `VERY_SMALL` | Score when the user has no known locations yet |
+| `adaptive-evaluator-known-location-score-KnownLocationRiskEvaluator` | `NEGATIVE_LOW` | Score when city and country match a known location |
+| `adaptive-evaluator-same-country-score-KnownLocationRiskEvaluator` | `VERY_SMALL` | Score when the country was seen before but the city is new |
+| `adaptive-evaluator-new-country-score-KnownLocationRiskEvaluator` | `MEDIUM` | Score when the login country was never seen before |
+
+Example for Browser:
+
+| Realm attribute | Default | Effect |
+|-----------------|---------|--------|
+| `adaptive-evaluator-known-browser-score-BrowserRiskEvaluator` | `NEGATIVE_LOW` | Score when the user agent matches a default known browser |
+| `adaptive-evaluator-unknown-browser-score-BrowserRiskEvaluator` | `MEDIUM` | Score when the user agent does not match a default known browser |
+
+Example for Operating system:
+
+| Realm attribute | Default | Effect |
+|-----------------|---------|--------|
+| `adaptive-evaluator-known-os-score-OperatingSystemRiskEvaluator` | `NEGATIVE_LOW` | Score for Linux, macOS, or recent Windows |
+| `adaptive-evaluator-legacy-windows-score-OperatingSystemRiskEvaluator` | `MEDIUM` | Score for older Windows versions |
+| `adaptive-evaluator-unknown-os-score-OperatingSystemRiskEvaluator` | `MEDIUM` | Score when the OS cannot be classified |
+
+Example for Known IP address (login events):
+
+| Realm attribute | Default | Effect |
+|-----------------|---------|--------|
+| `adaptive-evaluator-never-seen-ip-score-LoginEventIpAddressRiskEvaluator` | `HIGH` | Score when the current IP was never seen in login history |
+| `adaptive-evaluator-frequent-ip-score-LoginEventIpAddressRiskEvaluator` | `NEGATIVE_LOW` | Score when the IP appears often in recent logins |
+| `adaptive-evaluator-occasional-ip-score-LoginEventIpAddressRiskEvaluator` | `VERY_SMALL` | Score when the IP was seen before but not frequently |
+| `adaptive-evaluator-min-login-events-LoginEventIpAddressRiskEvaluator` | `4` | Minimum login events before frequent/occasional classification (below: invalid) |
+| `adaptive-evaluator-frequent-ip-threshold-divisor-LoginEventIpAddressRiskEvaluator` | `3` | IP is frequent when occurrences ≥ event count / divisor |
 
 ## Adding settings to an evaluator
 
 1. **Factory** — declare fields in `getAdditionalAdminConfigProperties()` using `EvaluatorSettingProperties` (score, int, string) or `ProviderConfigurationBuilder` directly.
-2. **Config class** — read values at runtime with `EvaluatorSettingUtils` (`getScore`, `getInt`, `getPositiveInt`).
-3. **Evaluator** — use the config class instead of hardcoded constants.
+2. **Config class** — getters only: keys, defaults, and `EvaluatorSettingUtils` reads (`getScore`, `getInt`, `getPositiveInt`).
+3. **Evaluator** — scoring logic uses the config getters instead of hardcoded constants.
 
 The risk-based policies tab renders, persists, and hydrates these properties automatically. No extra UI wiring is required.
 

--- a/docs/evaluator-settings.md
+++ b/docs/evaluator-settings.md
@@ -1,0 +1,67 @@
+# Evaluator settings
+
+Risk evaluators can expose realm-level settings beyond **enabled** and **trust**. These are stored as realm attributes and edited in **Authentication → Risk-based policies** (requires `declarative-ui`).
+
+## Naming convention
+
+```
+adaptive-evaluator-{settingKey}-{EvaluatorSimpleClassName}
+```
+
+Built with `RiskEvaluatorFactory.getAdditionalSettingConfig(evaluatorClass, settingKey)`.
+
+Example for Known location TTL:
+
+| Realm attribute | Default | Effect |
+|-----------------|---------|--------|
+| `adaptive-evaluator-ttl-days-KnownLocationRiskEvaluator` | `90` | Days before a known location stops providing a trust signal |
+
+## Adding settings to an evaluator
+
+1. **Factory** — declare fields in `getAdditionalAdminConfigProperties()` using `EvaluatorSettingProperties` (score, int, string) or `ProviderConfigurationBuilder` directly.
+2. **Config class** — read values at runtime with `EvaluatorSettingUtils` (`getScore`, `getInt`, `getPositiveInt`).
+3. **Evaluator** — use the config class instead of hardcoded constants.
+
+The risk-based policies tab renders, persists, and hydrates these properties automatically. No extra UI wiring is required.
+
+### Example: integer setting
+
+```java
+@Override
+public List<ProviderConfigProperty> getAdditionalAdminConfigProperties() {
+    return EvaluatorSettingProperties.of(
+            EvaluatorSettingProperties.intProperty(
+                    MyRiskEvaluator.class, "ttl-days",
+                    "TTL (days)", "Help text.", 90, 0));
+}
+```
+
+```java
+int ttlDays = EvaluatorSettingUtils.getInt(realm, MyRiskEvaluator.class, "ttl-days", 90);
+```
+
+### Example: risk score setting
+
+```java
+EvaluatorSettingProperties.scoreProperty(
+        MyRiskEvaluator.class, "known-score",
+        "Known case score", "Risk score when the trust signal applies.",
+        Risk.Score.NEGATIVE_LOW)
+```
+
+```java
+Risk.Score score = EvaluatorSettingUtils.getScore(
+        realm, MyRiskEvaluator.class, "known-score", Risk.Score.NEGATIVE_LOW);
+```
+
+## Legacy behavior
+
+Realms without these attributes keep the built-in defaults. No migration is required when upgrading the extension.
+
+Invalid or missing values fall back to defaults at runtime; authentication is not blocked by bad configuration. The admin tab validates risk score list fields when options match `EvaluatorSettingUtils.configurableScoreNames()`.
+
+## Related work
+
+When merging the IP whitelist extension, refactor `IpWhitelistEvaluatorConfig` to use `EvaluatorSettingUtils` instead of local score parsing.
+
+See also [Realm setup](realm-setup.md).

--- a/docs/realm-setup.md
+++ b/docs/realm-setup.md
@@ -67,3 +67,7 @@ On save, when at least one setting changed, one additional admin event is stored
 - detail value = `old > new` (e.g. `false > true`, `1500 > 2500`)
 
 No event on create, and no event on update when nothing changed.
+
+### Evaluator-specific settings
+
+Individual evaluators can expose extra realm settings (risk scores, thresholds, TTL) in the same **Risk-based policies** tab via `getAdditionalAdminConfigProperties()`. See [Evaluator settings](evaluator-settings.md) for naming conventions and how to add new fields.


### PR DESCRIPTION
## Summary

This PR generalises the pattern introduced with known-location TTL (#75) : realm-level evaluator settings stored as realm attributes, edited in Authentication → Risk-based policies with safe runtime fallbacks.

Several core evaluators still hardcode `Risk.Score` constants in Java. Admins can now tune scores per realm. Defaults are unchanged when no attribute is set.

Shared helpers (`EvaluatorSettingUtils`, `EvaluatorSettingProperties`) centralise key naming, UI property builders, and runtime reads.
Known-location persistence (`ttl-days`, `max-stored-locations`) lives in `KnownLocationSettings` under `context.location` and scoring stays in `*EvaluatorConfig` classes.

Evaluators covered (simpler ones) : Known location, Browser, Operating system, Login event IP address.

## Motivation

#75 showed that a single realm setting (TTL days) works well via `getAdditionalAdminConfigProperties()` and realm attributes. Other evaluators with a small fixed set of outcomes (known vs unknown browser, new country, never-seen IP, etc.) still require a rebuild to change scoring.

Goal : one consistent pattern for realm-tunable evaluator settings, less magic in code, more control for realm admins.
The approach can extend to other evaluators later.

Longer term, this pattern should make it easier to promote env-only extension settings (ex : IpApi, OpenRouter, AI Api Keys, ...) into the Risk-based policies tab where that makes sense, without reimplementing hydration and persistence each time.

Happy to adjust based on feedback, thanks for the review @mabartos 🙏