### PR TITLE
fix(ui): preserve additional evaluator settings on first save

### DIFF
--- a/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
+++ b/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
@@ -211,9 +211,18 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
             var key = prop.getName();
             if (model.contains(key)) {
                 storeRealmAttributeFromModel(model, realm, key, context);
-            } else if (realm.getAttribute(key) == null && prop.getDefaultValue() != null) {
-                logger.debugf("%s setting evaluator default '%s' = '%s'", context, key, prop.getDefaultValue());
-                realm.setAttribute(key, prop.getDefaultValue().toString());
+            } else if (StringUtil.isBlank(realm.getAttribute(key))) {
+                var persisted = resolvePersistedTabComponent(realm, model);
+                if (persisted != null
+                        && persisted.getConfig().containsKey(key)
+                        && StringUtil.isNotBlank(persisted.get(key))) {
+                    logger.debugf("%s migrating component evaluator setting '%s' = '%s' to realm",
+                            context, key, persisted.get(key));
+                    realm.setAttribute(key, persisted.get(key));
+                } else if (prop.getDefaultValue() != null) {
+                    logger.debugf("%s setting evaluator default '%s' = '%s'", context, key, prop.getDefaultValue());
+                    realm.setAttribute(key, prop.getDefaultValue().toString());
+                }
             }
         });
     }
@@ -276,6 +285,13 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
             var key = prop.getName();
             var realmValue = realm.getAttribute(key);
             if (isRealmSourcedEvaluatorSetting(key) || isAdditionalAdminConfigKey(key)) {
+                if (isAdditionalAdminConfigKey(key)
+                        && persisted == null
+                        && StringUtil.isBlank(realmValue)
+                        && StringUtil.isNotBlank(model.get(key))) {
+                    logger.tracef("Keeping first-save additional evaluator setting '%s' = '%s'", key, model.get(key));
+                    return;
+                }
                 applyRealmSourcedEvaluatorSettingHydration(model, persisted, key, realmValue);
                 return;
             }

--- a/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
+++ b/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
@@ -488,6 +488,36 @@ class RiskBasedPoliciesUiTabPersistenceTest {
     }
 
     @Test
+    void onUpdate_migratesStaleComponentAdditionalSettingToRealm() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+        var persisted = tabComponent(Map.of(KnownLocationContext.TTL_DAYS_CONFIG, "180"));
+        persisted.setId("risk-tab");
+        var newModel = componentModel(Map.of());
+        newModel.setId("risk-tab");
+        realm = realmBackedBy(realmAttributes, Map.of("risk-tab", persisted), List.of(persisted));
+
+        tab.onUpdate(null, realm, persisted, newModel);
+
+        assertEquals("180", realmAttributes.get(KnownLocationContext.TTL_DAYS_CONFIG));
+    }
+
+    @Test
+    void validateConfiguration_preservesAdditionalSettingOnFirstSaveWhenNoPersistedComponent() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+        var model = componentModel(Map.of(KnownLocationContext.TTL_DAYS_CONFIG, "45"));
+
+        tab.validateConfiguration(null, realm, model);
+
+        assertEquals("45", model.get(KnownLocationContext.TTL_DAYS_CONFIG));
+
+        tab.onUpdate(null, realm, new ComponentModel(), model);
+
+        assertEquals("45", realmAttributes.get(KnownLocationContext.TTL_DAYS_CONFIG));
+    }
+
+    @Test
     void validateConfiguration_discardsStaleModelTtlWhenNoRealmAttribute() throws Exception {
         var factory = new KnownLocationRiskEvaluatorFactory();
         injectFactories(tab, List.of(factory));


### PR DESCRIPTION
Fix Risk-based policies hydration so additional evaluator settings without a `defaultValue` are not cleared on first save when no realm attribute exists yet.

Split from #88 so it can be backported to 1.0.x independently.