### PR TITLE
fix(ui): validate additional evaluator integers before hydration

### DIFF
--- a/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
+++ b/core/src/main/java/io/github/mabartos/ui/RiskBasedPoliciesUiTab.java
@@ -223,6 +223,7 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
         logger.tracef("validateConfiguration execution");
 
         validateEvaluatorTrustValues(model);
+        validateSubmittedAdditionalEvaluatorSettings(model);
 
         var persisted = resolvePersistedTabComponent(realm, model);
         hydrateModelFromRealmAttributes(realm, model, persisted);
@@ -233,6 +234,11 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
 
         validateFallbackLevel(model.get(SIMPLE_FALLBACK_LEVEL_CONFIG), SimpleRiskLevels.getSimpleLevelNames(), "Simple fallback risk level");
         validateFallbackLevel(model.get(ADVANCED_FALLBACK_LEVEL_CONFIG), AdvancedRiskLevels.getAdvancedLevelNames(), "Advanced fallback risk level");
+
+        riskEvaluatorFactories.stream()
+                .flatMap(f -> f.getAdditionalAdminConfigProperties().stream())
+                .filter(prop -> ProviderConfigProperty.INTEGER_TYPE.equals(prop.getType()))
+                .forEach(prop -> validateInteger(model.get(prop.getName()), prop.getLabel()));
     }
 
     private void validateEvaluatorTrustValues(ComponentModel model) {
@@ -251,6 +257,18 @@ public class RiskBasedPoliciesUiTab implements UiTabProvider, UiTabProviderFacto
                         "Risk Trust levels must be double values in range [0.0, 1.0]");
             }
         });
+    }
+
+    private void validateSubmittedAdditionalEvaluatorSettings(ComponentModel model) {
+        riskEvaluatorFactories.stream()
+                .flatMap(factory -> factory.getAdditionalAdminConfigProperties().stream())
+                .filter(prop -> ProviderConfigProperty.INTEGER_TYPE.equals(prop.getType()))
+                .forEach(prop -> {
+                    var value = model.get(prop.getName());
+                    if (StringUtil.isNotBlank(value)) {
+                        validateInteger(value, prop.getLabel());
+                    }
+                });
     }
 
     private void populateMissingDefaults(ComponentModel model) {

--- a/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
+++ b/core/src/test/java/io/github/mabartos/ui/RiskBasedPoliciesUiTabPersistenceTest.java
@@ -405,6 +405,18 @@ class RiskBasedPoliciesUiTabPersistenceTest {
     }
 
     @Test
+    void validateConfiguration_rejectsNegativeKnownLocationTtl() throws Exception {
+        var factory = new KnownLocationRiskEvaluatorFactory();
+        injectFactories(tab, List.of(factory));
+
+        var model = componentModel(Map.of(
+                KnownLocationContext.TTL_DAYS_CONFIG, "-1"));
+
+        assertThrows(ComponentValidationException.class,
+                () -> tab.validateConfiguration(null, realm, model));
+    }
+
+    @Test
     void validateConfiguration_hydratesKnownLocationTtlFromRealmAttributeWhenModelEmpty() throws Exception {
         var factory = new KnownLocationRiskEvaluatorFactory();
         injectFactories(tab, List.of(factory));


### PR DESCRIPTION
On Risk-based policies, additional INTEGER evaluator settings (ex : Known Location TTL) were not reliably rejected when invalid on first save.

Hydration runs before the post-hydrate integer checks. On first save (`persisted == null`), an invalid value like `-1` is cleared / replaced by the default, so validation never sees the bad input and the admin gets no error.

This change:
1. Validates submitted additional INTEGER settings **before** hydration
2. Still validates them **after** hydration (covers later saves that keep an admin-submitted invalid value)